### PR TITLE
Support for nginx status in json format + patch for nginx 1.9.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains:
 
 Modified patch file from david-benes: extended_status-1.5.10.patch
 
-Added a patch file to support nginx-1.9.7
+Added a patch file to support nginx-1.9.7: [extended_status-1.9.7.4.patch](https://github.com/rohitjoshi/nginx_extended-status/blob/master/extended_status-1.9.7.4.patch)
 
 original file https://github.com/david-benes/ngx_http_extended_status_module/commit/7b4f66313d6092c29e2fe9f5c8ddcdda7bba21ae
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ nginx_extended-status
 This repo contains:
 
 Modified patch file from david-benes: extended_status-1.5.10.patch
+
 Added a patch file to support nginx-1.9.7
+
 original file https://github.com/david-benes/ngx_http_extended_status_module/commit/7b4f66313d6092c29e2fe9f5c8ddcdda7bba21ae
 
 Modified .spec file: nginx.spec

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ nginx_extended-status
 This repo contains:
 
 Modified patch file from david-benes: extended_status-1.5.10.patch
+Added a patch file to support nginx-1.9.7
 original file https://github.com/david-benes/ngx_http_extended_status_module/commit/7b4f66313d6092c29e2fe9f5c8ddcdda7bba21ae
 
 Modified .spec file: nginx.spec
@@ -12,3 +13,27 @@ Extended status module files:
 config
 ngx_http_extended_status_module.c
 ngx_http_extended_status_module.h
+
+###Usage
+
+##### HTML response:
+```
+location /nginx_status {
+          extended_status on;
+          access_log   off;
+          # allow 1.1.1.1;
+          # deny all;
+}
+```
+
+##### JSON response:
+```
+location /nginx_status {
+          extended_status on;
+          #enable response in json format
+          extended_status_content_type_json on;
+          access_log   off;
+          # allow 1.1.1.1;
+          # deny all;
+}
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains:
 
 Modified patch file from david-benes: extended_status-1.5.10.patch
 
-Added a patch file to support nginx-1.9.7: [extended_status-1.9.7.4.patch](https://github.com/rohitjoshi/nginx_extended-status/blob/master/extended_status-1.9.7.4.patch)
+Added a patch file to support nginx-1.9.7: [extended_status-1.9.7.4.patch](extended_status-1.9.7.4.patch)
 
 original file https://github.com/david-benes/ngx_http_extended_status_module/commit/7b4f66313d6092c29e2fe9f5c8ddcdda7bba21ae
 

--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 have=NGX_STAT_EXTENDED . auto/have
 
 ngx_addon_name=ngx_http_extended_status_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_extended_status_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_extended_status_module.c"
-NGX_ADDON_DEPS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_extended_status_module.h"
-
+HTTP_EXTENDED_STATUS_SRCS="$ngx_addon_dir/ngx_http_extended_status_module.c"
+HTTP_MODULES="$HTTP_MODULES $ngx_addon_name"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $HTTP_EXTENDED_STATUS_SRCS"
+NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/ngx_http_extended_status_module.h"

--- a/extended_status-1.9.7.4.patch
+++ b/extended_status-1.9.7.4.patch
@@ -1,0 +1,2910 @@
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/core/ngx_connection.c capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/core/ngx_connection.c
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/core/ngx_connection.c	2015-11-24 09:15:50.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/core/ngx_connection.c	2016-04-04 16:02:14.000000000 -0400
+@@ -949,7 +949,9 @@
+     ngx_uint_t         instance;
+     ngx_event_t       *rev, *wev;
+     ngx_connection_t  *c;
+-
++#if (NGX_STAT_EXTENDED)
++    conn_score        *cs;
++#endif
+     /* disable warning: Win32 SOCKET is u_int while UNIX socket is int */
+ 
+     if (ngx_cycle->files && (ngx_uint_t) s >= ngx_cycle->files_n) {
+@@ -984,9 +986,16 @@
+ 
+     rev = c->read;
+     wev = c->write;
++#if (NGX_STAT_EXTENDED)
++    cs = c->cs;
++#endif
+ 
+     ngx_memzero(c, sizeof(ngx_connection_t));
+ 
++#if (NGX_STAT_EXTENDED)
++    c->cs = cs;
++#endif
++
+     c->read = rev;
+     c->write = wev;
+     c->fd = s;
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/core/ngx_connection.h capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/core/ngx_connection.h
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/core/ngx_connection.h	2015-11-24 09:15:50.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/core/ngx_connection.h	2016-04-04 13:13:20.000000000 -0400
+@@ -122,6 +122,9 @@
+ 
+ 
+ struct ngx_connection_s {
++#if (NGX_STAT_EXTENDED)
++    void               *cs;
++#endif
+     void               *data;
+     ngx_event_t        *read;
+     ngx_event_t        *write;
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/event/ngx_event.c capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/event/ngx_event.c
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/event/ngx_event.c	2015-11-24 09:15:50.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/event/ngx_event.c	2016-04-04 13:32:07.000000000 -0400
+@@ -57,7 +57,7 @@
+ ngx_int_t             ngx_accept_disabled;
+ 
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB  || NGX_STAT_EXTENDED)
+ 
+ ngx_atomic_t   ngx_stat_accepted0;
+ ngx_atomic_t  *ngx_stat_accepted = &ngx_stat_accepted0;
+@@ -76,7 +76,15 @@
+ 
+ #endif
+ 
+-
++#if (NGX_STAT_EXTENDED)
++      
++    ngx_uint_t      ngx_num_workers;
++    size_t          shm_size = 0;
++    worker_score   *workers;
++    conn_score     *conns;
++    worker_score   *my_worker;
++ 
++#endif
+ 
+ static ngx_command_t  ngx_events_commands[] = {
+ 
+@@ -327,6 +335,40 @@
+     return NGX_OK;
+ }
+ 
++#if (NGX_STAT_EXTENDED)
++ 
++static void
++init_request_cnt(request_cnt *recent_request_cnt)
++ {
++     ngx_uint_t  i;
++ 
++     for (i = 0; i < RECENT_PERIOD; i++) {
++         recent_request_cnt[i].time = 0;
++         recent_request_cnt[i].cnt = 0;
++     }
++}
++ 
++ 
++static void
++init_workers(worker_score *workers)
++{
++     worker_score  *ws;
++     ngx_uint_t  i;
++ 
++     for (i = 0; i < ngx_num_workers; i++)
++     {
++         ws = (worker_score *)((char *) workers + WORKER_SCORE_LEN * i);
++ 
++         ws->pid = 0;
++         ws->access_count = 0;
++         ws->bytes_sent = 0;
++         ws->mode = SERVER_READY;
++ 
++         init_request_cnt(ws->recent_request_cnt);
++     }
++}
++ 
++#endif
+ 
+ ngx_int_t
+ ngx_handle_write_event(ngx_event_t *wev, size_t lowat)
+@@ -475,7 +517,13 @@
+     }
+ 
+     if (ngx_accept_mutex_ptr) {
++#if (NGX_STAT_EXTENDED)
++      shm.addr = (u_char *) ngx_accept_mutex_ptr;
++      shm.size = shm_size;
++      ngx_shm_free(&shm);
++#else
+         return NGX_OK;
++#endif
+     }
+ 
+ 
+@@ -487,7 +535,7 @@
+            + cl          /* ngx_connection_counter */
+            + cl;         /* ngx_temp_number */
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB || NGX_STAT_EXTENDED)
+ 
+     size += cl           /* ngx_stat_accepted */
+            + cl          /* ngx_stat_handled */
+@@ -498,6 +546,19 @@
+            + cl;         /* ngx_stat_waiting */
+ 
+ #endif
++#if (NGX_STAT_EXTENDED)
++ 
++   if (WORKER_SCORE_LEN < sizeof(worker_score)) {
++        ngx_log_error(NGX_LOG_EMERG, cycle->log, 0, "worker_score(%d) too large", sizeof(worker_score ));
++        return NGX_ERROR;
++   }
++ 
++   size += (WORKER_SCORE_LEN * ccf->worker_processes)
++       + (sizeof(conn_score) * ccf->worker_processes * cycle->connection_n);
++ 
++   shm_size = size;
++ 
++#endif
+ 
+     shm.size = size;
+     shm.name.len = sizeof("nginx_shared_zone") - 1;
+@@ -534,7 +595,7 @@
+ 
+     ngx_random_number = (tp->msec << 16) + ngx_pid;
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB || NGX_STAT_EXTENDED)
+ 
+     ngx_stat_accepted = (ngx_atomic_t *) (shared + 3 * cl);
+     ngx_stat_handled = (ngx_atomic_t *) (shared + 4 * cl);
+@@ -545,7 +606,15 @@
+     ngx_stat_waiting = (ngx_atomic_t *) (shared + 9 * cl);
+ 
+ #endif
++#if (NGX_STAT_EXTENDED)
++ 
++    ngx_num_workers = ccf->worker_processes;
++    workers = (worker_score *) (shared + 10 * cl);
++    init_workers(workers);
+ 
++    conns = (conn_score *) (shared + 10 * cl + ccf->worker_processes * WORKER_SCORE_LEN);
++ 
++#endif
+     return NGX_OK;
+ }
+ 
+@@ -689,6 +758,38 @@
+ 
+     c = cycle->connections;
+ 
++#if (NGX_STAT_EXTENDED)
++   {
++      ngx_time_t  *tp;
++      conn_score  *cs;
++      ngx_uint_t    i;
++ 
++      for (i = 0; i < cycle->connection_n; i++) 
++      {
++           c [i].cs = (void *) ((char *) conns +
++                  sizeof(conn_score) * (ngx_process_slot * cycle->connection_n + i));
++           cs = (conn_score *) c[i].cs;
++             
++           cs->bytes_sent = 0;
++           cs->access_count = 0;
++           cs->response_time = 0;
++           cs->upstream_response_time = -1;
++           cs->request[0] = '\0';
++           cs->client[0] = '\0';
++           cs->vhost[0] = '\0';
++           cs->mode = SERVER_READY;
++             
++           tp = ngx_timeofday();
++           cs->last_used = tp->sec;
++           cs->status = 0;
++           cs->zin = 0;
++           cs->zout = 0;
++           cs->active = 0;
++       }
++   }
++#endif
++                    
++
+     cycle->read_events = ngx_alloc(sizeof(ngx_event_t) * cycle->connection_n,
+                                    cycle->log);
+     if (cycle->read_events == NULL) {
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/event/ngx_event.h capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/event/ngx_event.h
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/event/ngx_event.h	2015-11-24 09:15:50.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/event/ngx_event.h	2016-04-04 13:37:26.000000000 -0400
+@@ -12,6 +12,9 @@
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ 
++#if (NGX_STAT_EXTENDED)
++#include <sys/times.h>
++#endif
+ 
+ #define NGX_INVALID_INDEX  0xd0d0d0d0
+ 
+@@ -462,7 +465,7 @@
+ extern ngx_int_t              ngx_accept_disabled;
+ 
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB || NGX_STAT_EXTENDED)
+ 
+ extern ngx_atomic_t  *ngx_stat_accepted;
+ extern ngx_atomic_t  *ngx_stat_handled;
+@@ -474,6 +477,87 @@
+ 
+ #endif
+ 
++#if (NGX_STAT_EXTENDED)
++ 
++#define  SCORE__REQUEST_LEN            128
++#define  SCORE__CLIENT_LEN              32
++#define  SCORE__VHOST_LEN               32
++ 
++#define  CL_SIZE                       128
++#define  WORKER_SCORE_LEN              640      /* 128 X 5 */
++ 
++#define  SERVER_READY                   '-'
++#define  SERVER_BUSY_READ               'R'
++#define  SERVER_BUSY_WRITE              'W'
++#define  SERVER_BUSY_LOG                'L'
++#define  SERVER_DEAD                    'I'
++ 
++#define  RECENT_PERIOD                  64
++#define  RECENT_MASK            0x0000003F
++ 
++typedef struct {
++        uint32_t  time;
++        uint32_t  cnt;
++} request_cnt;
++     
++     
++typedef struct {
++        request_cnt     recent_request_cnt[RECENT_PERIOD];
++        struct  tms     times;
++        time_t          last_used;
++        ngx_uint_t      bytes_sent;
++        ngx_uint_t      access_count;
++        ngx_pid_t       pid;
++        char            mode;
++} worker_score;
++         
++         
++typedef struct {
++         u_char  request[SCORE__REQUEST_LEN];
++         u_char  client[SCORE__CLIENT_LEN];
++         u_char  vhost[SCORE__VHOST_LEN];
++         time_t          last_used;
++         ngx_uint_t      bytes_sent;
++         ngx_uint_t      access_count;
++         char            mode ;
++         ngx_msec_int_t  response_time;
++         ngx_msec_int_t  upstream_response_time;
++         ngx_uint_t      status;
++         size_t          zin;
++         size_t          zout;
++         char            active;
++} conn_score;
++             
++             
++extern  worker_score  *workers;
++extern  worker_score  *my_worker;
++extern  conn_score    *conns;
++             
++             
++static inline void
++set_conn_active(ngx_connection_t *c)
++{
++         conn_score  *score = (conn_score *) c->cs;
++         score->active = 1 ;
++}
++     
++     
++static inline void
++set_conn_inactive(ngx_connection_t *c)
++{
++         conn_score  *score = (conn_score *) c->cs;
++         score->active = 0 ;
++}
++     
++     
++static inline void
++set_conn_mode(ngx_connection_t *c, char mode)
++ {
++         conn_score  *score = (conn_score *) c->cs;
++         score->mode = mode ;
++ }
++     
++#endif
+ 
+ #define NGX_UPDATE_TIME         1
+ #define NGX_POST_EVENTS         2
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/event/ngx_event_accept.c capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/event/ngx_event_accept.c
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/event/ngx_event_accept.c	2015-11-24 09:15:50.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/event/ngx_event_accept.c	2016-04-04 13:18:51.000000000 -0400
+@@ -131,7 +131,7 @@
+             return;
+         }
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB || NGX_STAT_EXTENDED)
+         (void) ngx_atomic_fetch_add(ngx_stat_accepted, 1);
+ #endif
+ 
+@@ -149,9 +149,13 @@
+             return;
+         }
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB || NGX_STAT_EXTENDED)
+         (void) ngx_atomic_fetch_add(ngx_stat_active, 1);
+ #endif
++#if (NGX_STAT_EXTENDED)
++         set_conn_active(c);
++         set_conn_mode(c, SERVER_READY);
++#endif
+ 
+         c->pool = ngx_create_pool(ls->pool_size, ev->log);
+         if (c->pool == NULL) {
+@@ -254,7 +258,7 @@
+ 
+         c->number = ngx_atomic_fetch_add(ngx_connection_counter, 1);
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB || NGX_STAT_EXTENDED )
+         (void) ngx_atomic_fetch_add(ngx_stat_handled, 1);
+ #endif
+ 
+@@ -485,9 +489,13 @@
+         ngx_destroy_pool(c->pool);
+     }
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB || NGX_STAT_EXTENDED)
+     (void) ngx_atomic_fetch_add(ngx_stat_active, -1);
+ #endif
++#if (NGX_STAT_EXTENDED)
++     set_conn_inactive(c);
++    set_conn_mode(c, SERVER_DEAD);
++#endif
+ }
+ 
+ 
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/http/modules/ngx_http_gzip_filter_module.c capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/http/modules/ngx_http_gzip_filter_module.c
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/http/modules/ngx_http_gzip_filter_module.c	2015-11-24 09:15:50.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/http/modules/ngx_http_gzip_filter_module.c	2016-04-05 10:16:15.000000000 -0400
+@@ -978,7 +978,14 @@
+     ctx->done = 1;
+ 
+     r->connection->buffered &= ~NGX_HTTP_GZIP_BUFFERED;
+-
++#if (NGX_STAT_EXTENDED)
++    {
++        conn_score  *cs = r->connection->cs;
++       
++        cs->zin = ctx->zin;
++        cs->zout = ctx->zout;
++    }
++#endif
+     return NGX_OK;
+ }
+ 
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/http/ngx_http_gzip_filter_module.c capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/http/ngx_http_gzip_filter_module.c
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/http/ngx_http_gzip_filter_module.c	1969-12-31 19:00:00.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/http/ngx_http_gzip_filter_module.c	2016-04-04 16:04:17.000000000 -0400
+@@ -0,0 +1,1243 @@
++
++/*
++ * Copyright (C) Igor Sysoev
++ * Copyright (C) Nginx, Inc.
++ */
++
++
++#include <ngx_config.h>
++#include <ngx_core.h>
++#include <ngx_http.h>
++
++#include <zlib.h>
++
++
++typedef struct {
++    ngx_flag_t           enable;
++    ngx_flag_t           no_buffer;
++
++    ngx_hash_t           types;
++
++    ngx_bufs_t           bufs;
++
++    size_t               postpone_gzipping;
++    ngx_int_t            level;
++    size_t               wbits;
++    size_t               memlevel;
++    ssize_t              min_length;
++
++    ngx_array_t         *types_keys;
++} ngx_http_gzip_conf_t;
++
++
++typedef struct {
++    ngx_chain_t         *in;
++    ngx_chain_t         *free;
++    ngx_chain_t         *busy;
++    ngx_chain_t         *out;
++    ngx_chain_t        **last_out;
++
++    ngx_chain_t         *copied;
++    ngx_chain_t         *copy_buf;
++
++    ngx_buf_t           *in_buf;
++    ngx_buf_t           *out_buf;
++    ngx_int_t            bufs;
++
++    void                *preallocated;
++    char                *free_mem;
++    ngx_uint_t           allocated;
++
++    int                  wbits;
++    int                  memlevel;
++
++    unsigned             flush:4;
++    unsigned             redo:1;
++    unsigned             done:1;
++    unsigned             nomem:1;
++    unsigned             gzheader:1;
++    unsigned             buffering:1;
++
++    size_t               zin;
++    size_t               zout;
++
++    uint32_t             crc32;
++    z_stream             zstream;
++    ngx_http_request_t  *request;
++} ngx_http_gzip_ctx_t;
++
++
++#if (NGX_HAVE_LITTLE_ENDIAN && NGX_HAVE_NONALIGNED)
++
++struct gztrailer {
++    uint32_t  crc32;
++    uint32_t  zlen;
++};
++
++#else /* NGX_HAVE_BIG_ENDIAN || !NGX_HAVE_NONALIGNED */
++
++struct gztrailer {
++    u_char  crc32[4];
++    u_char  zlen[4];
++};
++
++#endif
++
++
++static void ngx_http_gzip_filter_memory(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx);
++static ngx_int_t ngx_http_gzip_filter_buffer(ngx_http_gzip_ctx_t *ctx,
++    ngx_chain_t *in);
++static ngx_int_t ngx_http_gzip_filter_deflate_start(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx);
++static ngx_int_t ngx_http_gzip_filter_gzheader(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx);
++static ngx_int_t ngx_http_gzip_filter_add_data(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx);
++static ngx_int_t ngx_http_gzip_filter_get_buf(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx);
++static ngx_int_t ngx_http_gzip_filter_deflate(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx);
++static ngx_int_t ngx_http_gzip_filter_deflate_end(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx);
++
++static void *ngx_http_gzip_filter_alloc(void *opaque, u_int items,
++    u_int size);
++static void ngx_http_gzip_filter_free(void *opaque, void *address);
++static void ngx_http_gzip_filter_free_copy_buf(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx);
++
++static ngx_int_t ngx_http_gzip_add_variables(ngx_conf_t *cf);
++static ngx_int_t ngx_http_gzip_ratio_variable(ngx_http_request_t *r,
++    ngx_http_variable_value_t *v, uintptr_t data);
++
++static ngx_int_t ngx_http_gzip_filter_init(ngx_conf_t *cf);
++static void *ngx_http_gzip_create_conf(ngx_conf_t *cf);
++static char *ngx_http_gzip_merge_conf(ngx_conf_t *cf,
++    void *parent, void *child);
++static char *ngx_http_gzip_window(ngx_conf_t *cf, void *post, void *data);
++static char *ngx_http_gzip_hash(ngx_conf_t *cf, void *post, void *data);
++
++
++static ngx_conf_num_bounds_t  ngx_http_gzip_comp_level_bounds = {
++    ngx_conf_check_num_bounds, 1, 9
++};
++
++static ngx_conf_post_handler_pt  ngx_http_gzip_window_p = ngx_http_gzip_window;
++static ngx_conf_post_handler_pt  ngx_http_gzip_hash_p = ngx_http_gzip_hash;
++
++
++static ngx_command_t  ngx_http_gzip_filter_commands[] = {
++
++    { ngx_string("gzip"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
++                        |NGX_CONF_FLAG,
++      ngx_conf_set_flag_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_gzip_conf_t, enable),
++      NULL },
++
++    { ngx_string("gzip_buffers"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
++      ngx_conf_set_bufs_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_gzip_conf_t, bufs),
++      NULL },
++
++    { ngx_string("gzip_types"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
++      ngx_http_types_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_gzip_conf_t, types_keys),
++      &ngx_http_html_default_types[0] },
++
++    { ngx_string("gzip_comp_level"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
++      ngx_conf_set_num_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_gzip_conf_t, level),
++      &ngx_http_gzip_comp_level_bounds },
++
++    { ngx_string("gzip_window"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
++      ngx_conf_set_size_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_gzip_conf_t, wbits),
++      &ngx_http_gzip_window_p },
++
++    { ngx_string("gzip_hash"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
++      ngx_conf_set_size_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_gzip_conf_t, memlevel),
++      &ngx_http_gzip_hash_p },
++
++    { ngx_string("postpone_gzipping"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
++      ngx_conf_set_size_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_gzip_conf_t, postpone_gzipping),
++      NULL },
++
++    { ngx_string("gzip_no_buffer"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_flag_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_gzip_conf_t, no_buffer),
++      NULL },
++
++    { ngx_string("gzip_min_length"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
++      ngx_conf_set_size_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_gzip_conf_t, min_length),
++      NULL },
++
++      ngx_null_command
++};
++
++
++static ngx_http_module_t  ngx_http_gzip_filter_module_ctx = {
++    ngx_http_gzip_add_variables,           /* preconfiguration */
++    ngx_http_gzip_filter_init,             /* postconfiguration */
++
++    NULL,                                  /* create main configuration */
++    NULL,                                  /* init main configuration */
++
++    NULL,                                  /* create server configuration */
++    NULL,                                  /* merge server configuration */
++
++    ngx_http_gzip_create_conf,             /* create location configuration */
++    ngx_http_gzip_merge_conf               /* merge location configuration */
++};
++
++
++ngx_module_t  ngx_http_gzip_filter_module = {
++    NGX_MODULE_V1,
++    &ngx_http_gzip_filter_module_ctx,      /* module context */
++    ngx_http_gzip_filter_commands,         /* module directives */
++    NGX_HTTP_MODULE,                       /* module type */
++    NULL,                                  /* init master */
++    NULL,                                  /* init module */
++    NULL,                                  /* init process */
++    NULL,                                  /* init thread */
++    NULL,                                  /* exit thread */
++    NULL,                                  /* exit process */
++    NULL,                                  /* exit master */
++    NGX_MODULE_V1_PADDING
++};
++
++
++static ngx_str_t  ngx_http_gzip_ratio = ngx_string("gzip_ratio");
++
++static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;
++static ngx_http_output_body_filter_pt    ngx_http_next_body_filter;
++
++
++static ngx_int_t
++ngx_http_gzip_header_filter(ngx_http_request_t *r)
++{
++    ngx_table_elt_t       *h;
++    ngx_http_gzip_ctx_t   *ctx;
++    ngx_http_gzip_conf_t  *conf;
++
++    conf = ngx_http_get_module_loc_conf(r, ngx_http_gzip_filter_module);
++
++    if (!conf->enable
++        || (r->headers_out.status != NGX_HTTP_OK
++            && r->headers_out.status != NGX_HTTP_FORBIDDEN
++            && r->headers_out.status != NGX_HTTP_NOT_FOUND)
++        || (r->headers_out.content_encoding
++            && r->headers_out.content_encoding->value.len)
++        || (r->headers_out.content_length_n != -1
++            && r->headers_out.content_length_n < conf->min_length)
++        || ngx_http_test_content_type(r, &conf->types) == NULL
++        || r->header_only)
++    {
++        return ngx_http_next_header_filter(r);
++    }
++
++    r->gzip_vary = 1;
++
++#if (NGX_HTTP_DEGRADATION)
++    {
++    ngx_http_core_loc_conf_t  *clcf;
++
++    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
++
++    if (clcf->gzip_disable_degradation && ngx_http_degraded(r)) {
++        return ngx_http_next_header_filter(r);
++    }
++    }
++#endif
++
++    if (!r->gzip_tested) {
++        if (ngx_http_gzip_ok(r) != NGX_OK) {
++            return ngx_http_next_header_filter(r);
++        }
++
++    } else if (!r->gzip_ok) {
++        return ngx_http_next_header_filter(r);
++    }
++
++    ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_gzip_ctx_t));
++    if (ctx == NULL) {
++        return NGX_ERROR;
++    }
++
++    ngx_http_set_ctx(r, ctx, ngx_http_gzip_filter_module);
++
++    ctx->request = r;
++    ctx->buffering = (conf->postpone_gzipping != 0);
++
++    ngx_http_gzip_filter_memory(r, ctx);
++
++    h = ngx_list_push(&r->headers_out.headers);
++    if (h == NULL) {
++        return NGX_ERROR;
++    }
++
++    h->hash = 1;
++    ngx_str_set(&h->key, "Content-Encoding");
++    ngx_str_set(&h->value, "gzip");
++    r->headers_out.content_encoding = h;
++
++    r->main_filter_need_in_memory = 1;
++
++    ngx_http_clear_content_length(r);
++    ngx_http_clear_accept_ranges(r);
++    ngx_http_weak_etag(r);
++
++    return ngx_http_next_header_filter(r);
++}
++
++
++static ngx_int_t
++ngx_http_gzip_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
++{
++    int                   rc;
++    ngx_uint_t            flush;
++    ngx_chain_t          *cl;
++    ngx_http_gzip_ctx_t  *ctx;
++
++    ctx = ngx_http_get_module_ctx(r, ngx_http_gzip_filter_module);
++
++    if (ctx == NULL || ctx->done || r->header_only) {
++        return ngx_http_next_body_filter(r, in);
++    }
++
++    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
++                   "http gzip filter");
++
++    if (ctx->buffering) {
++
++        /*
++         * With default memory settings zlib starts to output gzipped data
++         * only after it has got about 90K, so it makes sense to allocate
++         * zlib memory (200-400K) only after we have enough data to compress.
++         * Although we copy buffers, nevertheless for not big responses
++         * this allows to allocate zlib memory, to compress and to output
++         * the response in one step using hot CPU cache.
++         */
++
++        if (in) {
++            switch (ngx_http_gzip_filter_buffer(ctx, in)) {
++
++            case NGX_OK:
++                return NGX_OK;
++
++            case NGX_DONE:
++                in = NULL;
++                break;
++
++            default:  /* NGX_ERROR */
++                goto failed;
++            }
++
++        } else {
++            ctx->buffering = 0;
++        }
++    }
++
++    if (ctx->preallocated == NULL) {
++        if (ngx_http_gzip_filter_deflate_start(r, ctx) != NGX_OK) {
++            goto failed;
++        }
++    }
++
++    if (in) {
++        if (ngx_chain_add_copy(r->pool, &ctx->in, in) != NGX_OK) {
++            goto failed;
++        }
++
++        r->connection->buffered |= NGX_HTTP_GZIP_BUFFERED;
++    }
++
++    if (ctx->nomem) {
++
++        /* flush busy buffers */
++
++        if (ngx_http_next_body_filter(r, NULL) == NGX_ERROR) {
++            goto failed;
++        }
++
++        cl = NULL;
++
++        ngx_chain_update_chains(r->pool, &ctx->free, &ctx->busy, &cl,
++                                (ngx_buf_tag_t) &ngx_http_gzip_filter_module);
++        ctx->nomem = 0;
++        flush = 0;
++
++    } else {
++        flush = ctx->busy ? 1 : 0;
++    }
++
++    for ( ;; ) {
++
++        /* cycle while we can write to a client */
++
++        for ( ;; ) {
++
++            /* cycle while there is data to feed zlib and ... */
++
++            rc = ngx_http_gzip_filter_add_data(r, ctx);
++
++            if (rc == NGX_DECLINED) {
++                break;
++            }
++
++            if (rc == NGX_AGAIN) {
++                continue;
++            }
++
++
++            /* ... there are buffers to write zlib output */
++
++            rc = ngx_http_gzip_filter_get_buf(r, ctx);
++
++            if (rc == NGX_DECLINED) {
++                break;
++            }
++
++            if (rc == NGX_ERROR) {
++                goto failed;
++            }
++
++
++            rc = ngx_http_gzip_filter_deflate(r, ctx);
++
++            if (rc == NGX_OK) {
++                break;
++            }
++
++            if (rc == NGX_ERROR) {
++                goto failed;
++            }
++
++            /* rc == NGX_AGAIN */
++        }
++
++        if (ctx->out == NULL && !flush) {
++            ngx_http_gzip_filter_free_copy_buf(r, ctx);
++
++            return ctx->busy ? NGX_AGAIN : NGX_OK;
++        }
++
++        if (!ctx->gzheader) {
++            if (ngx_http_gzip_filter_gzheader(r, ctx) != NGX_OK) {
++                goto failed;
++            }
++        }
++
++        rc = ngx_http_next_body_filter(r, ctx->out);
++
++        if (rc == NGX_ERROR) {
++            goto failed;
++        }
++
++        ngx_http_gzip_filter_free_copy_buf(r, ctx);
++
++        ngx_chain_update_chains(r->pool, &ctx->free, &ctx->busy, &ctx->out,
++                                (ngx_buf_tag_t) &ngx_http_gzip_filter_module);
++        ctx->last_out = &ctx->out;
++
++        ctx->nomem = 0;
++        flush = 0;
++
++        if (ctx->done) {
++            return rc;
++        }
++    }
++
++    /* unreachable */
++
++failed:
++
++    ctx->done = 1;
++
++    if (ctx->preallocated) {
++        deflateEnd(&ctx->zstream);
++
++        ngx_pfree(r->pool, ctx->preallocated);
++    }
++
++    ngx_http_gzip_filter_free_copy_buf(r, ctx);
++
++    return NGX_ERROR;
++}
++
++
++static void
++ngx_http_gzip_filter_memory(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
++{
++    int                    wbits, memlevel;
++    ngx_http_gzip_conf_t  *conf;
++
++    conf = ngx_http_get_module_loc_conf(r, ngx_http_gzip_filter_module);
++
++    wbits = conf->wbits;
++    memlevel = conf->memlevel;
++
++    if (r->headers_out.content_length_n > 0) {
++
++        /* the actual zlib window size is smaller by 262 bytes */
++
++        while (r->headers_out.content_length_n < ((1 << (wbits - 1)) - 262)) {
++            wbits--;
++            memlevel--;
++        }
++
++        if (memlevel < 1) {
++            memlevel = 1;
++        }
++    }
++
++    ctx->wbits = wbits;
++    ctx->memlevel = memlevel;
++
++    /*
++     * We preallocate a memory for zlib in one buffer (200K-400K), this
++     * decreases a number of malloc() and free() calls and also probably
++     * decreases a number of syscalls (sbrk()/mmap() and so on).
++     * Besides we free the memory as soon as a gzipping will complete
++     * and do not wait while a whole response will be sent to a client.
++     *
++     * 8K is for zlib deflate_state, it takes
++     *  *) 5816 bytes on i386 and sparc64 (32-bit mode)
++     *  *) 5920 bytes on amd64 and sparc64
++     */
++
++    ctx->allocated = 8192 + (1 << (wbits + 2)) + (1 << (memlevel + 9));
++}
++
++
++static ngx_int_t
++ngx_http_gzip_filter_buffer(ngx_http_gzip_ctx_t *ctx, ngx_chain_t *in)
++{
++    size_t                 size, buffered;
++    ngx_buf_t             *b, *buf;
++    ngx_chain_t           *cl, **ll;
++    ngx_http_request_t    *r;
++    ngx_http_gzip_conf_t  *conf;
++
++    r = ctx->request;
++
++    r->connection->buffered |= NGX_HTTP_GZIP_BUFFERED;
++
++    buffered = 0;
++    ll = &ctx->in;
++
++    for (cl = ctx->in; cl; cl = cl->next) {
++        buffered += cl->buf->last - cl->buf->pos;
++        ll = &cl->next;
++    }
++
++    conf = ngx_http_get_module_loc_conf(r, ngx_http_gzip_filter_module);
++
++    while (in) {
++        cl = ngx_alloc_chain_link(r->pool);
++        if (cl == NULL) {
++            return NGX_ERROR;
++        }
++
++        b = in->buf;
++
++        size = b->last - b->pos;
++        buffered += size;
++
++        if (b->flush || b->last_buf || buffered > conf->postpone_gzipping) {
++            ctx->buffering = 0;
++        }
++
++        if (ctx->buffering && size) {
++
++            buf = ngx_create_temp_buf(r->pool, size);
++            if (buf == NULL) {
++                return NGX_ERROR;
++            }
++
++            buf->last = ngx_cpymem(buf->pos, b->pos, size);
++            b->pos = b->last;
++
++            buf->last_buf = b->last_buf;
++            buf->tag = (ngx_buf_tag_t) &ngx_http_gzip_filter_module;
++
++            cl->buf = buf;
++
++        } else {
++            cl->buf = b;
++        }
++
++        *ll = cl;
++        ll = &cl->next;
++        in = in->next;
++    }
++
++    *ll = NULL;
++
++    return ctx->buffering ? NGX_OK : NGX_DONE;
++}
++
++
++static ngx_int_t
++ngx_http_gzip_filter_deflate_start(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx)
++{
++    int                    rc;
++    ngx_http_gzip_conf_t  *conf;
++
++    conf = ngx_http_get_module_loc_conf(r, ngx_http_gzip_filter_module);
++
++    ctx->preallocated = ngx_palloc(r->pool, ctx->allocated);
++    if (ctx->preallocated == NULL) {
++        return NGX_ERROR;
++    }
++
++    ctx->free_mem = ctx->preallocated;
++
++    ctx->zstream.zalloc = ngx_http_gzip_filter_alloc;
++    ctx->zstream.zfree = ngx_http_gzip_filter_free;
++    ctx->zstream.opaque = ctx;
++
++    rc = deflateInit2(&ctx->zstream, (int) conf->level, Z_DEFLATED,
++                      - ctx->wbits, ctx->memlevel, Z_DEFAULT_STRATEGY);
++
++    if (rc != Z_OK) {
++        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                      "deflateInit2() failed: %d", rc);
++        return NGX_ERROR;
++    }
++
++    ctx->last_out = &ctx->out;
++    ctx->crc32 = crc32(0L, Z_NULL, 0);
++    ctx->flush = Z_NO_FLUSH;
++
++    return NGX_OK;
++}
++
++
++static ngx_int_t
++ngx_http_gzip_filter_gzheader(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
++{
++    ngx_buf_t      *b;
++    ngx_chain_t    *cl;
++    static u_char  gzheader[10] =
++                               { 0x1f, 0x8b, Z_DEFLATED, 0, 0, 0, 0, 0, 0, 3 };
++
++    b = ngx_pcalloc(r->pool, sizeof(ngx_buf_t));
++    if (b == NULL) {
++        return NGX_ERROR;
++    }
++
++    b->memory = 1;
++    b->pos = gzheader;
++    b->last = b->pos + 10;
++
++    cl = ngx_alloc_chain_link(r->pool);
++    if (cl == NULL) {
++        return NGX_ERROR;
++    }
++
++    cl->buf = b;
++    cl->next = ctx->out;
++    ctx->out = cl;
++
++    ctx->gzheader = 1;
++
++    return NGX_OK;
++}
++
++
++static ngx_int_t
++ngx_http_gzip_filter_add_data(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
++{
++    if (ctx->zstream.avail_in || ctx->flush != Z_NO_FLUSH || ctx->redo) {
++        return NGX_OK;
++    }
++
++    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
++                   "gzip in: %p", ctx->in);
++
++    if (ctx->in == NULL) {
++        return NGX_DECLINED;
++    }
++
++    if (ctx->copy_buf) {
++
++        /*
++         * to avoid CPU cache trashing we do not free() just quit buf,
++         * but postpone free()ing after zlib compressing and data output
++         */
++
++        ctx->copy_buf->next = ctx->copied;
++        ctx->copied = ctx->copy_buf;
++        ctx->copy_buf = NULL;
++    }
++
++    ctx->in_buf = ctx->in->buf;
++
++    if (ctx->in_buf->tag == (ngx_buf_tag_t) &ngx_http_gzip_filter_module) {
++        ctx->copy_buf = ctx->in;
++    }
++
++    ctx->in = ctx->in->next;
++
++    ctx->zstream.next_in = ctx->in_buf->pos;
++    ctx->zstream.avail_in = ctx->in_buf->last - ctx->in_buf->pos;
++
++    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
++                   "gzip in_buf:%p ni:%p ai:%ud",
++                   ctx->in_buf,
++                   ctx->zstream.next_in, ctx->zstream.avail_in);
++
++    if (ctx->in_buf->last_buf) {
++        ctx->flush = Z_FINISH;
++
++    } else if (ctx->in_buf->flush) {
++        ctx->flush = Z_SYNC_FLUSH;
++    }
++
++    if (ctx->zstream.avail_in) {
++
++        ctx->crc32 = crc32(ctx->crc32, ctx->zstream.next_in,
++                           ctx->zstream.avail_in);
++
++    } else if (ctx->flush == Z_NO_FLUSH) {
++        return NGX_AGAIN;
++    }
++
++    return NGX_OK;
++}
++
++
++static ngx_int_t
++ngx_http_gzip_filter_get_buf(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
++{
++    ngx_http_gzip_conf_t  *conf;
++
++    if (ctx->zstream.avail_out) {
++        return NGX_OK;
++    }
++
++    conf = ngx_http_get_module_loc_conf(r, ngx_http_gzip_filter_module);
++
++    if (ctx->free) {
++        ctx->out_buf = ctx->free->buf;
++        ctx->free = ctx->free->next;
++
++    } else if (ctx->bufs < conf->bufs.num) {
++
++        ctx->out_buf = ngx_create_temp_buf(r->pool, conf->bufs.size);
++        if (ctx->out_buf == NULL) {
++            return NGX_ERROR;
++        }
++
++        ctx->out_buf->tag = (ngx_buf_tag_t) &ngx_http_gzip_filter_module;
++        ctx->out_buf->recycled = 1;
++        ctx->bufs++;
++
++    } else {
++        ctx->nomem = 1;
++        return NGX_DECLINED;
++    }
++
++    ctx->zstream.next_out = ctx->out_buf->pos;
++    ctx->zstream.avail_out = conf->bufs.size;
++
++    return NGX_OK;
++}
++
++
++static ngx_int_t
++ngx_http_gzip_filter_deflate(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
++{
++    int                    rc;
++    ngx_buf_t             *b;
++    ngx_chain_t           *cl;
++    ngx_http_gzip_conf_t  *conf;
++
++    ngx_log_debug6(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
++                 "deflate in: ni:%p no:%p ai:%ud ao:%ud fl:%d redo:%d",
++                 ctx->zstream.next_in, ctx->zstream.next_out,
++                 ctx->zstream.avail_in, ctx->zstream.avail_out,
++                 ctx->flush, ctx->redo);
++
++    rc = deflate(&ctx->zstream, ctx->flush);
++
++    if (rc != Z_OK && rc != Z_STREAM_END && rc != Z_BUF_ERROR) {
++        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                      "deflate() failed: %d, %d", ctx->flush, rc);
++        return NGX_ERROR;
++    }
++
++    ngx_log_debug5(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
++                   "deflate out: ni:%p no:%p ai:%ud ao:%ud rc:%d",
++                   ctx->zstream.next_in, ctx->zstream.next_out,
++                   ctx->zstream.avail_in, ctx->zstream.avail_out,
++                   rc);
++
++    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
++                   "gzip in_buf:%p pos:%p",
++                   ctx->in_buf, ctx->in_buf->pos);
++
++    if (ctx->zstream.next_in) {
++        ctx->in_buf->pos = ctx->zstream.next_in;
++
++        if (ctx->zstream.avail_in == 0) {
++            ctx->zstream.next_in = NULL;
++        }
++    }
++
++    ctx->out_buf->last = ctx->zstream.next_out;
++
++    if (ctx->zstream.avail_out == 0) {
++
++        /* zlib wants to output some more gzipped data */
++
++        cl = ngx_alloc_chain_link(r->pool);
++        if (cl == NULL) {
++            return NGX_ERROR;
++        }
++
++        cl->buf = ctx->out_buf;
++        cl->next = NULL;
++        *ctx->last_out = cl;
++        ctx->last_out = &cl->next;
++
++        ctx->redo = 1;
++
++        return NGX_AGAIN;
++    }
++
++    ctx->redo = 0;
++
++    if (ctx->flush == Z_SYNC_FLUSH) {
++
++        ctx->flush = Z_NO_FLUSH;
++
++        cl = ngx_alloc_chain_link(r->pool);
++        if (cl == NULL) {
++            return NGX_ERROR;
++        }
++
++        b = ctx->out_buf;
++
++        if (ngx_buf_size(b) == 0) {
++
++            b = ngx_calloc_buf(ctx->request->pool);
++            if (b == NULL) {
++                return NGX_ERROR;
++            }
++
++        } else {
++            ctx->zstream.avail_out = 0;
++        }
++
++        b->flush = 1;
++
++        cl->buf = b;
++        cl->next = NULL;
++        *ctx->last_out = cl;
++        ctx->last_out = &cl->next;
++
++        r->connection->buffered &= ~NGX_HTTP_GZIP_BUFFERED;
++
++        return NGX_OK;
++    }
++
++    if (rc == Z_STREAM_END) {
++
++        if (ngx_http_gzip_filter_deflate_end(r, ctx) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_OK;
++    }
++
++    conf = ngx_http_get_module_loc_conf(r, ngx_http_gzip_filter_module);
++
++    if (conf->no_buffer && ctx->in == NULL) {
++
++        cl = ngx_alloc_chain_link(r->pool);
++        if (cl == NULL) {
++            return NGX_ERROR;
++        }
++
++        cl->buf = ctx->out_buf;
++        cl->next = NULL;
++        *ctx->last_out = cl;
++        ctx->last_out = &cl->next;
++
++        return NGX_OK;
++    }
++
++    return NGX_AGAIN;
++}
++
++
++static ngx_int_t
++ngx_http_gzip_filter_deflate_end(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx)
++{
++    int                rc;
++    ngx_buf_t         *b;
++    ngx_chain_t       *cl;
++    struct gztrailer  *trailer;
++
++    ctx->zin = ctx->zstream.total_in;
++    ctx->zout = 10 + ctx->zstream.total_out + 8;
++
++    rc = deflateEnd(&ctx->zstream);
++
++    if (rc != Z_OK) {
++        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
++                      "deflateEnd() failed: %d", rc);
++        return NGX_ERROR;
++    }
++
++    ngx_pfree(r->pool, ctx->preallocated);
++
++    cl = ngx_alloc_chain_link(r->pool);
++    if (cl == NULL) {
++        return NGX_ERROR;
++    }
++
++    cl->buf = ctx->out_buf;
++    cl->next = NULL;
++    *ctx->last_out = cl;
++    ctx->last_out = &cl->next;
++
++    if (ctx->zstream.avail_out >= 8) {
++        trailer = (struct gztrailer *) ctx->out_buf->last;
++        ctx->out_buf->last += 8;
++        ctx->out_buf->last_buf = 1;
++
++    } else {
++        b = ngx_create_temp_buf(r->pool, 8);
++        if (b == NULL) {
++            return NGX_ERROR;
++        }
++
++        b->last_buf = 1;
++
++        cl = ngx_alloc_chain_link(r->pool);
++        if (cl == NULL) {
++            return NGX_ERROR;
++        }
++
++        cl->buf = b;
++        cl->next = NULL;
++        *ctx->last_out = cl;
++        ctx->last_out = &cl->next;
++        trailer = (struct gztrailer *) b->pos;
++        b->last += 8;
++    }
++
++#if (NGX_HAVE_LITTLE_ENDIAN && NGX_HAVE_NONALIGNED)
++
++    trailer->crc32 = ctx->crc32;
++    trailer->zlen = ctx->zin;
++
++#else
++
++    trailer->crc32[0] = (u_char) (ctx->crc32 & 0xff);
++    trailer->crc32[1] = (u_char) ((ctx->crc32 >> 8) & 0xff);
++    trailer->crc32[2] = (u_char) ((ctx->crc32 >> 16) & 0xff);
++    trailer->crc32[3] = (u_char) ((ctx->crc32 >> 24) & 0xff);
++
++    trailer->zlen[0] = (u_char) (ctx->zin & 0xff);
++    trailer->zlen[1] = (u_char) ((ctx->zin >> 8) & 0xff);
++    trailer->zlen[2] = (u_char) ((ctx->zin >> 16) & 0xff);
++    trailer->zlen[3] = (u_char) ((ctx->zin >> 24) & 0xff);
++
++#endif
++
++    ctx->zstream.avail_in = 0;
++    ctx->zstream.avail_out = 0;
++
++    ctx->done = 1;
++
++    r->connection->buffered &= ~NGX_HTTP_GZIP_BUFFERED;
++#if (NGX_STAT_EXTENDED)
++    {
++        conn_score  *cs = r->connection->cs;
++       
++        cs->zin = ctx->zin;
++        cs->zout = ctx->zout;
++    }
++#endif
++             
++    return NGX_OK;
++}
++
++
++static void *
++ngx_http_gzip_filter_alloc(void *opaque, u_int items, u_int size)
++{
++    ngx_http_gzip_ctx_t *ctx = opaque;
++
++    void        *p;
++    ngx_uint_t   alloc;
++
++    alloc = items * size;
++
++    if (alloc % 512 != 0 && alloc < 8192) {
++
++        /*
++         * The zlib deflate_state allocation, it takes about 6K,
++         * we allocate 8K.  Other allocations are divisible by 512.
++         */
++
++        alloc = 8192;
++    }
++
++    if (alloc <= ctx->allocated) {
++        p = ctx->free_mem;
++        ctx->free_mem += alloc;
++        ctx->allocated -= alloc;
++
++        ngx_log_debug4(NGX_LOG_DEBUG_HTTP, ctx->request->connection->log, 0,
++                       "gzip alloc: n:%ud s:%ud a:%ud p:%p",
++                       items, size, alloc, p);
++
++        return p;
++    }
++
++    ngx_log_error(NGX_LOG_ALERT, ctx->request->connection->log, 0,
++                  "gzip filter failed to use preallocated memory: %ud of %ud",
++                  items * size, ctx->allocated);
++
++    p = ngx_palloc(ctx->request->pool, items * size);
++
++    return p;
++}
++
++
++static void
++ngx_http_gzip_filter_free(void *opaque, void *address)
++{
++#if 0
++    ngx_http_gzip_ctx_t *ctx = opaque;
++
++    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ctx->request->connection->log, 0,
++                   "gzip free: %p", address);
++#endif
++}
++
++
++static void
++ngx_http_gzip_filter_free_copy_buf(ngx_http_request_t *r,
++    ngx_http_gzip_ctx_t *ctx)
++{
++    ngx_chain_t  *cl;
++
++    for (cl = ctx->copied; cl; cl = cl->next) {
++        ngx_pfree(r->pool, cl->buf->start);
++    }
++
++    ctx->copied = NULL;
++}
++
++
++static ngx_int_t
++ngx_http_gzip_add_variables(ngx_conf_t *cf)
++{
++    ngx_http_variable_t  *var;
++
++    var = ngx_http_add_variable(cf, &ngx_http_gzip_ratio, NGX_HTTP_VAR_NOHASH);
++    if (var == NULL) {
++        return NGX_ERROR;
++    }
++
++    var->get_handler = ngx_http_gzip_ratio_variable;
++
++    return NGX_OK;
++}
++
++
++static ngx_int_t
++ngx_http_gzip_ratio_variable(ngx_http_request_t *r,
++    ngx_http_variable_value_t *v, uintptr_t data)
++{
++    ngx_uint_t            zint, zfrac;
++    ngx_http_gzip_ctx_t  *ctx;
++
++    v->valid = 1;
++    v->no_cacheable = 0;
++    v->not_found = 0;
++
++    ctx = ngx_http_get_module_ctx(r, ngx_http_gzip_filter_module);
++
++    if (ctx == NULL || ctx->zout == 0) {
++        v->not_found = 1;
++        return NGX_OK;
++    }
++
++    v->data = ngx_pnalloc(r->pool, NGX_INT32_LEN + 3);
++    if (v->data == NULL) {
++        return NGX_ERROR;
++    }
++
++    zint = (ngx_uint_t) (ctx->zin / ctx->zout);
++    zfrac = (ngx_uint_t) ((ctx->zin * 100 / ctx->zout) % 100);
++
++    if ((ctx->zin * 1000 / ctx->zout) % 10 > 4) {
++
++        /* the rounding, e.g., 2.125 to 2.13 */
++
++        zfrac++;
++
++        if (zfrac > 99) {
++            zint++;
++            zfrac = 0;
++        }
++    }
++
++    v->len = ngx_sprintf(v->data, "%ui.%02ui", zint, zfrac) - v->data;
++
++    return NGX_OK;
++}
++
++
++static void *
++ngx_http_gzip_create_conf(ngx_conf_t *cf)
++{
++    ngx_http_gzip_conf_t  *conf;
++
++    conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_gzip_conf_t));
++    if (conf == NULL) {
++        return NULL;
++    }
++
++    /*
++     * set by ngx_pcalloc():
++     *
++     *     conf->bufs.num = 0;
++     *     conf->types = { NULL };
++     *     conf->types_keys = NULL;
++     */
++
++    conf->enable = NGX_CONF_UNSET;
++    conf->no_buffer = NGX_CONF_UNSET;
++
++    conf->postpone_gzipping = NGX_CONF_UNSET_SIZE;
++    conf->level = NGX_CONF_UNSET;
++    conf->wbits = NGX_CONF_UNSET_SIZE;
++    conf->memlevel = NGX_CONF_UNSET_SIZE;
++    conf->min_length = NGX_CONF_UNSET;
++
++    return conf;
++}
++
++
++static char *
++ngx_http_gzip_merge_conf(ngx_conf_t *cf, void *parent, void *child)
++{
++    ngx_http_gzip_conf_t *prev = parent;
++    ngx_http_gzip_conf_t *conf = child;
++
++    ngx_conf_merge_value(conf->enable, prev->enable, 0);
++    ngx_conf_merge_value(conf->no_buffer, prev->no_buffer, 0);
++
++    ngx_conf_merge_bufs_value(conf->bufs, prev->bufs,
++                              (128 * 1024) / ngx_pagesize, ngx_pagesize);
++
++    ngx_conf_merge_size_value(conf->postpone_gzipping, prev->postpone_gzipping,
++                              0);
++    ngx_conf_merge_value(conf->level, prev->level, 1);
++    ngx_conf_merge_size_value(conf->wbits, prev->wbits, MAX_WBITS);
++    ngx_conf_merge_size_value(conf->memlevel, prev->memlevel,
++                              MAX_MEM_LEVEL - 1);
++    ngx_conf_merge_value(conf->min_length, prev->min_length, 20);
++
++    if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
++                             &prev->types_keys, &prev->types,
++                             ngx_http_html_default_types)
++        != NGX_OK)
++    {
++        return NGX_CONF_ERROR;
++    }
++
++    return NGX_CONF_OK;
++}
++
++
++static ngx_int_t
++ngx_http_gzip_filter_init(ngx_conf_t *cf)
++{
++    ngx_http_next_header_filter = ngx_http_top_header_filter;
++    ngx_http_top_header_filter = ngx_http_gzip_header_filter;
++
++    ngx_http_next_body_filter = ngx_http_top_body_filter;
++    ngx_http_top_body_filter = ngx_http_gzip_body_filter;
++
++    return NGX_OK;
++}
++
++
++static char *
++ngx_http_gzip_window(ngx_conf_t *cf, void *post, void *data)
++{
++    size_t *np = data;
++
++    size_t  wbits, wsize;
++
++    wbits = 15;
++
++    for (wsize = 32 * 1024; wsize > 256; wsize >>= 1) {
++
++        if (wsize == *np) {
++            *np = wbits;
++
++            return NGX_CONF_OK;
++        }
++
++        wbits--;
++    }
++
++    return "must be 512, 1k, 2k, 4k, 8k, 16k, or 32k";
++}
++
++
++static char *
++ngx_http_gzip_hash(ngx_conf_t *cf, void *post, void *data)
++{
++    size_t *np = data;
++
++    size_t  memlevel, hsize;
++
++    memlevel = 9;
++
++    for (hsize = 128 * 1024; hsize > 256; hsize >>= 1) {
++
++        if (hsize == *np) {
++            *np = memlevel;
++
++            return NGX_CONF_OK;
++        }
++
++        memlevel--;
++    }
++
++    return "must be 512, 1k, 2k, 4k, 8k, 16k, 32k, 64k, or 128k";
++}
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/http/ngx_http_request.c capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/http/ngx_http_request.c
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/http/ngx_http_request.c	2016-03-16 20:37:26.000000000 -0400
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/http/ngx_http_request.c	2016-04-05 10:33:58.000000000 -0400
+@@ -602,12 +602,23 @@
+     ctx->current_request = r;
+     r->log_handler = ngx_http_log_error_handler;
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB  || NGX_STAT_EXTENDED)
+     (void) ngx_atomic_fetch_add(ngx_stat_reading, 1);
+     r->stat_reading = 1;
+     (void) ngx_atomic_fetch_add(ngx_stat_requests, 1);
+ #endif
+ 
++#if (NGX_STAT_EXTENDED)
++    {
++        conn_score  *cs = (conn_score *) c->cs;
++        ngx_time_t  *tp = ngx_timeofday();
++ 
++        my_worker->mode = SERVER_BUSY_READ;
++        set_conn_mode(c, SERVER_BUSY_READ);
++        cs->last_used = tp->sec;
++     }
++#endif
++ 
+     return r;
+ }
+ 
+@@ -1895,13 +1906,18 @@
+         ngx_del_timer(c->read);
+     }
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB  || NGX_STAT_EXTENDED)
+     (void) ngx_atomic_fetch_add(ngx_stat_reading, -1);
+     r->stat_reading = 0;
+     (void) ngx_atomic_fetch_add(ngx_stat_writing, 1);
+     r->stat_writing = 1;
+ #endif
+ 
++#if (NGX_STAT_EXTENDED)
++   my_worker->mode = SERVER_BUSY_WRITE;
++   set_conn_mode(c, SERVER_BUSY_WRITE);
++#endif
++
+     c->read->handler = ngx_http_request_handler;
+     c->write->handler = ngx_http_request_handler;
+     r->read_event_handler = ngx_http_block_reading;
+@@ -1911,6 +1927,61 @@
+     ngx_http_run_posted_requests(c);
+ }
+ 
++#if (NGX_STAT_EXTENDED)
++ 
++static inline void
++update_request_cnt(worker_score *worker, conn_score *cs, uint32_t sec)
++{
++     uint32_t  index;
++ 
++     index = sec & RECENT_MASK;
++     if (sec == worker->recent_request_cnt[index].time) {
++         worker->recent_request_cnt[index].cnt += 1;
++     }
++     else {
++         worker->recent_request_cnt[index].time = sec;
++         worker->recent_request_cnt[index].cnt = 1;
++     }
++}
++ 
++ 
++static inline  ngx_msec_int_t
++get_response_time(ngx_time_t *tp, ngx_http_request_t *r)
++{
++    ngx_msec_int_t  ms;
++ 
++    ms = (ngx_msec_int_t) ((tp->sec - r->start_sec) * 1000 + (tp->msec - r->start_msec));
++    ms = ( 0 <= ms ) ? ms : 0;
++ 
++    return ms;
++}
++ 
++static inline  ngx_msec_int_t
++get_proxy_response_time(ngx_http_request_t  *r)
++{
++    ngx_http_upstream_state_t  *state;
++    ngx_msec_int_t  ms = -1;
++    ngx_uint_t  i;
++     
++     if (NULL != r->upstream_states && 0 < r->upstream_states->nelts)
++     {
++          state = r->upstream_states->elts;
++          for (i = 0; i < r->upstream_states->nelts; i++)
++          {
++               if (0 != state[i].status)
++               {
++                    ms = (ngx_msec_int_t) (state[i].response_time );
++                    //ms = (ngx_msec_int_t) (state[i].response_sec * 1000 + state [i].response_msec);
++                    ms = (0 <= ms) ? ms : 0;
++                    break;
++                }
++           }
++      }
++     
++     return ms;
++}
++ 
++#endif
+ 
+ static ngx_int_t
+ ngx_http_validate_host(ngx_str_t *host, ngx_pool_t *pool, ngx_uint_t alloc)
+@@ -3440,6 +3511,11 @@
+     ngx_http_log_ctx_t        *ctx;
+     ngx_http_core_loc_conf_t  *clcf;
+ 
++#if (NGX_STAT_EXTENDED)
++     conn_score  *cs = r->connection->cs;
++     ngx_time_t  *tp ;
++#endif
++
+     log = r->connection->log;
+ 
+     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, log, 0, "http close request");
+@@ -3460,7 +3536,7 @@
+         cln = cln->next;
+     }
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB  || NGX_STAT_EXTENDED)
+ 
+     if (r->stat_reading) {
+         (void) ngx_atomic_fetch_add(ngx_stat_reading, -1);
+@@ -3478,6 +3554,49 @@
+ 
+     log->action = "logging request";
+ 
++#if (NGX_STAT_EXTENDED)
++    my_worker->mode = SERVER_BUSY_LOG;
++    set_conn_mode(r->connection, SERVER_BUSY_LOG);
++
++    if (0 < r->headers_in.server.len &&  NULL != r->request_line.data) {
++      
++          tp = ngx_timeofday();
++      
++          if (my_worker->last_used != tp->sec)
++              times(&(my_worker->times ));
++      
++              my_worker->last_used = tp->sec;
++              cs->last_used = tp->sec;
++      
++              cs->response_time = get_response_time(tp, r);
++              cs->upstream_response_time = get_proxy_response_time(r);
++      
++              my_worker->bytes_sent += r->connection->sent;
++              cs->bytes_sent = r->connection->sent;
++      
++              my_worker->access_count++;
++              cs->access_count++;
++      
++              update_request_cnt(my_worker, cs, (uint32_t) tp->sec);
++      
++              cs->status = r->err_status ? r->err_status : r->headers_out.status;
++      
++              if (NULL != r->connection->addr_text.data) {
++                  ngx_cpystrn(cs->client, r->connection->addr_text.data,
++                  r->connection->addr_text.len >= SCORE__CLIENT_LEN ?
++                  SCORE__CLIENT_LEN : (r->connection->addr_text.len + 1));
++              }
++             if (0 < r->headers_in.server.len) {
++                  ngx_cpystrn(cs->vhost, r->headers_in.server.data, SCORE__VHOST_LEN <= r->headers_in.server.len ?
++                  SCORE__VHOST_LEN : (r->headers_in.server.len + 1));
++              }
++             if (NULL != r->request_line.data) {
++                 ngx_cpystrn(cs->request, r->request_line.data, r->request_line.len >= SCORE__REQUEST_LEN ?
++                            SCORE__REQUEST_LEN : (r->request_line.len + 1));
++             }
++     }
++#endif
++
+     ngx_http_log_request(r);
+ 
+     log->action = "closing request";
+@@ -3498,6 +3617,11 @@
+         }
+     }
+ 
++#if (NGX_STAT_EXTENDED)
++    my_worker->mode = SERVER_READY;
++    set_conn_mode(r->connection, SERVER_READY);
++#endif
++
+     /* the various request strings were allocated from r->pool */
+     ctx = log->data;
+     ctx->request = NULL;
+@@ -3555,10 +3679,15 @@
+ 
+ #endif
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB  || NGX_STAT_EXTENDED)
+     (void) ngx_atomic_fetch_add(ngx_stat_active, -1);
+ #endif
+ 
++#if (NGX_STAT_EXTENDED)
++    set_conn_inactive(c);
++   set_conn_mode(c, SERVER_DEAD);
++#endif
++
+     c->destroyed = 1;
+ 
+     pool = c->pool;
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/http/ngx_http_request.h capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/http/ngx_http_request.h
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/http/ngx_http_request.h	2015-11-24 09:15:50.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/http/ngx_http_request.h	2016-04-04 14:54:05.000000000 -0400
+@@ -533,7 +533,7 @@
+     unsigned                          single_range:1;
+     unsigned                          disable_not_modified:1;
+ 
+-#if (NGX_STAT_STUB)
++#if (NGX_STAT_STUB || NGX_STAT_EXTENDED)
+     unsigned                          stat_reading:1;
+     unsigned                          stat_writing:1;
+ #endif
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/os/unix/ngx_process.c capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/os/unix/ngx_process.c
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/os/unix/ngx_process.c	2015-11-24 09:15:50.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/os/unix/ngx_process.c	2016-04-04 14:54:53.000000000 -0400
+@@ -35,6 +35,10 @@
+ ngx_int_t        ngx_last_process;
+ ngx_process_t    ngx_processes[NGX_MAX_PROCESSES];
+ 
++#if (NGX_STAT_EXTENDED)
++  ngx_int_t        old_ngx_last_process = 0;
++  ngx_process_t    old_ngx_processes[NGX_MAX_PROCESSES];
++#endif
+ 
+ ngx_signal_t  signals[] = {
+     { ngx_signal_value(NGX_RECONFIGURE_SIGNAL),
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/os/unix/ngx_process.h capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/os/unix/ngx_process.h
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/os/unix/ngx_process.h	2015-11-24 09:15:50.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/os/unix/ngx_process.h	2016-04-04 15:08:35.000000000 -0400
+@@ -84,5 +84,9 @@
+ extern ngx_int_t      ngx_last_process;
+ extern ngx_process_t  ngx_processes[NGX_MAX_PROCESSES];
+ 
++#if (NGX_STAT_EXTENDED)
++extern ngx_int_t      old_ngx_last_process;
++extern ngx_process_t  old_ngx_processes[NGX_MAX_PROCESSES];
++#endif
+ 
+ #endif /* _NGX_PROCESS_H_INCLUDED_ */
+diff -ruN capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/os/unix/ngx_process_cycle.c capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/os/unix/ngx_process_cycle.c
+--- capione_ngx-1.9.7.4/bundle/nginx-1.9.7/src/os/unix/ngx_process_cycle.c	2016-03-16 20:37:26.000000000 -0400
++++ capione_ngx-1.9.7.4-new/bundle/nginx-1.9.7/src/os/unix/ngx_process_cycle.c	2016-04-04 15:07:44.000000000 -0400
+@@ -231,6 +231,15 @@
+ 
+             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reconfiguring");
+ 
++#if (NGX_STAT_EXTENDED)
++       old_ngx_last_process = ngx_last_process;
++       for (i = 0; i < old_ngx_last_process; i++) {
++            old_ngx_processes[i] = ngx_processes[i];
++       }
++       ngx_last_process = 0;
++       ngx_process_slot = 0;
++#endif
++
+             cycle = ngx_init_cycle(cycle);
+             if (cycle == NULL) {
+                 cycle = (ngx_cycle_t *) ngx_cycle;
+@@ -488,6 +497,64 @@
+ 
+     ch.fd = -1;
+ 
++#if (NGX_STAT_EXTENDED)
++    if ( NGX_CMD_QUIT == ch.command && 0 < old_ngx_last_process )
++    {
++        for (i = 0; i < old_ngx_last_process; i++) {
++             ngx_log_debug7(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
++                           "child: %d %P e:%d t:%d d:%d r:%d j:%d",
++                            i,
++                            old_ngx_processes[i].pid,
++                            old_ngx_processes[i].exiting,
++                            old_ngx_processes[i].exited,
++                            old_ngx_processes[i].detached,
++                            old_ngx_processes[i].respawn,
++                            old_ngx_processes[i].just_spawn);
++             
++            if (old_ngx_processes[i].detached || old_ngx_processes[i].pid == -1)
++                 continue;
++              
++            if (old_ngx_processes[i].exiting && signo == ngx_signal_value( NGX_SHUTDOWN_SIGNAL))
++                 continue;
++              
++            if (ch.command) {
++                 if (ngx_write_channel(old_ngx_processes[i].channel[0], &ch, sizeof(ngx_channel_t), cycle->log) == NGX_OK) {
++                      if (signo != ngx_signal_value(NGX_REOPEN_SIGNAL))
++                          old_ngx_processes[i].exiting = 1;
++                      
++                      continue;
++                  }
++            }
++              
++           ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
++                         "kill (%P, %d)", old_ngx_processes[i].pid, signo);
++              
++           if (kill(old_ngx_processes[i].pid, signo) == -1) {
++               err = ngx_errno;
++               ngx_log_error(NGX_LOG_ALERT, cycle->log, err,
++                            "kill(%P, %d) failed", old_ngx_processes[i].pid, signo);
++                    
++               if (err == NGX_ESRCH) {
++                      old_ngx_processes[i].exited = 1;
++                      old_ngx_processes[i].exiting = 0;
++                      ngx_reap = 1;
++                }
++                continue;
++           }
++                
++          if (signo != ngx_signal_value(NGX_REOPEN_SIGNAL))
++                old_ngx_processes[i].exiting = 1;
++          }
++           
++         old_ngx_last_process = -1;
++    
++         for (i = 0; i < ngx_last_process; i++) {
++              ngx_processes [i].just_spawn = 0 ;
++         }
++         
++        return ;
++    }
++#endif
+ 
+     for (i = 0; i < ngx_last_process; i++) {
+ 
+@@ -735,6 +802,21 @@
+ 
+     ngx_setproctitle("worker process");
+ 
++#if (NGX_STAT_EXTENDED)
++    {
++        my_worker = (worker_score *) ((char *) workers + WORKER_SCORE_LEN * ngx_process_slot);
++        ngx_time_t  *tp = ngx_timeofday();
++         
++        my_worker->last_used = tp->sec;
++        my_worker->pid = ngx_getpid();
++        my_worker->bytes_sent = 0L;
++        my_worker->access_count = 0L;
++        my_worker->mode = SERVER_READY;
++         
++        times(&my_worker->times);
++     }
++#endif
++
+     for ( ;; ) {
+ 
+         if (ngx_exiting) {
+diff -ruN capione_ngx-1.9.7.4/bundle/ngx_http_extended_status_module/config capione_ngx-1.9.7.4-new/bundle/ngx_http_extended_status_module/config
+--- capione_ngx-1.9.7.4/bundle/ngx_http_extended_status_module/config	1969-12-31 19:00:00.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/ngx_http_extended_status_module/config	2016-04-04 15:58:33.000000000 -0400
+@@ -0,0 +1,7 @@
++have=NGX_STAT_EXTENDED . auto/have
++
++ngx_addon_name=ngx_http_extended_status_module
++HTTP_MODULES="$HTTP_MODULES ngx_http_extended_status_module"
++NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_extended_status_module.c"
++NGX_ADDON_DEPS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_extended_status_module.h"
++
+diff -ruN capione_ngx-1.9.7.4/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module copy.h capione_ngx-1.9.7.4-new/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module copy.h
+--- capione_ngx-1.9.7.4/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module copy.h	1969-12-31 19:00:00.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module copy.h	2016-04-04 15:15:20.000000000 -0400
+@@ -0,0 +1,65 @@
++
++
++#define  HTML_HEADER    "<html><head><title>Nginx Status</title>\n" \
++        "<script type=text/javascript src=tablesort.min.js></script>\n" \
++        "<style type=text/css><!--\n" \
++        "body{font:bold 15px Georgia, Helvetica, sans-serif;color:#4f6b72;}\n" \
++        "table{border-top:1px solid #e5eff8;border-right:1px solid #e5eff8;border-collapse:collapse;}\n" \
++        "th{font:bold 10px \"Century Gothic\", \"Trebuchet MS\", Helvetica, sans-serif;letter-spacing:1px;text-transform:uppercase;background:#f4f9fe;color:#66a3d3;border-bottom:1px solid #e5eff8;border-left:1px solid #e5eff8;padding:8px 5px;}\n" \
++        "td{border-bottom:1px solid #e5eff8;border-left:1px solid #e5eff8;}\n" \
++        "tbody td{font:13px Calibri,\"Trebuchet MS\", Helvetica, sans-serif;padding:5px;}\n" \
++        "tr:hover{background: #d0dafd;color:#000000}\n" \
++        "--></style>\n" \
++        "</head>\n<body>\n"
++
++#define  HTML_TAIL        "\n</body></html>"
++
++#define  SAVE_THIS_PAGE   "<input type=button onclick=javascript:saveCurrentState() value=\"Save this page\"><br><br>\n"
++
++#define  SERVER_INFO      "<h1> Nginx Server Status for %s</h1>\n<dl><dt>Server Version: Nginx/%s </dt></dl>\n"
++
++
++#define  WORKER_TABLE_HEADER   "<br><br>\n<table border=0><tr><th>Worker</th><th>PID</th><th>Acc</th><th>Mode</th><th>CPU</th>" \
++                               "<th>Mbytes</th></tr>\n" 
++
++#define  CURRENT_TIME          "<script type=text/javascript> var date = new Date() ; document.write( date.toLocaleString() );</script>"
++
++#define  CONNECTION_TABLE_HEADER     "<br><br>\n<table class=sortable-onload-%s cellspacing=1 border=0 cellpadding=1>\n" \
++                               "<thead><tr><th class=sortable>Worker</th><th class=sortable>Acc</th><th class=sortable>M</th>\n" \
++                               "<th class=sortable>Bytes</th><th class=sortable>Client</th><th class=sortable>VHost</th>\n" \
++                               "<th class=sortable>Gzip Ratio</th><th class=sortable>SS</th><th class=sortable>Status</th>\n" \
++                               "<th class=sortable>TIME</th><th class=sortable>Proxy TIME</th><th class=sortable>Request</th></tr></thead><tbody>\n"
++
++#define  GZIP_HEADER    "<th class=sortable>Gzip Ratio</th>"
++#define  PROXY_HEADER   "<th class=sortable>Proxy TIME</th>"
++
++#define  SHORTENED_TABLE  "<table>\n"  \
++                     "<tr><th>PID</th><td>OS process ID</td></tr>\n" \
++                     "<tr><th>Acc</th><td>Number of requests serviced with this connection slot</td></tr>\n" \
++                     "<tr><th>M</th><td>Mode of operation</td></tr>\n" \
++                     "<tr><th>CPU</th><td>Accumulated CPU usage in seconds</td></tr>\n" \
++                     "<tr><th>Gzip Ratio</th><td>Ratio of original size to compressed size </td>\n" \
++                     "<tr><th>SS</th><td>Seconds since the request completion</td></tr>\n" \
++                     "<tr><th>Proxy TIME</th><td> Proxy response time in milliseconds. 0 means the value is less than 1 millisecond</td></tr>\n" \
++                     "<tr><th>TIME</th><td>Response time in milliseconds. 0 means the value is less than 1 millisecond</td></tr>\n" \
++                     "</table>\n" 
++
++#define  MODE_LIST  "<b>Mode List</b><br><table>" \
++                    "<tr><th>-</th><td>Waiting for request</td></tr>\n" \
++                    "<tr><th>R</th><td>Reading request</td></tr>\n" \
++                    "<tr><th>W</th><td>Sending reply</td></tr>\n" \
++                    "<tr><th>L</th><td>Logging</td></tr>\n" \
++                    "<tr><th>I</th><td>Inactive connection</td></tr>\n"
++
++
++#define  MBYTE  1048576.0
++
++#define  DEFAULT_REQ_VALUE    0
++
++#define  MIN_REFRESH_VALUE    0
++#define  MAX_REFRESH_VALUE   60
++
++#define  PERIOD_S     10    /* 10 seconds */
++#define  PERIOD_L     60    /* 60 seconds */
++
++
+diff -ruN capione_ngx-1.9.7.4/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module.c capione_ngx-1.9.7.4-new/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module.c
+--- capione_ngx-1.9.7.4/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module.c	1969-12-31 19:00:00.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module.c	2016-04-04 15:13:28.000000000 -0400
+@@ -0,0 +1,663 @@
++
++#include <nginx.h>
++#include <ngx_config.h>
++#include <ngx_core.h>
++#include <ngx_http.h>
++
++#include <ctype.h>
++#include <assert.h>
++
++#include "ngx_http_extended_status_module.h"
++
++extern  ngx_uint_t  ngx_num_workers;
++
++static char  * ngx_http_set_status(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
++
++static ngx_command_t  ngx_http_status_commands[] = {
++
++    { ngx_string("extended_status"),
++      NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
++      ngx_http_set_status,
++      0,
++      0,
++      NULL },
++
++      ngx_null_command
++};
++
++
++static ngx_http_module_t  ngx_http_extended_status_module_ctx = {
++    NULL,                                  /* preconfiguration */
++    NULL,                                  /* postconfiguration */
++
++    NULL,                                  /* create main configuration */
++    NULL,                                  /* init main configuration */
++
++    NULL,                                  /* create server configuration */
++    NULL,                                  /* merge server configuration */
++
++    NULL,                                  /* create location configuration */
++    NULL                                   /* merge location configuration */
++};
++
++
++ngx_module_t  ngx_http_extended_status_module = {
++    NGX_MODULE_V1,
++    &ngx_http_extended_status_module_ctx,      /* module context */
++    ngx_http_status_commands,              /* module directives */
++    NGX_HTTP_MODULE,                       /* module type */
++    NULL,                                  /* init master */
++    NULL,                                  /* init module */
++    NULL,                                  /* init process */
++    NULL,                                  /* init thread */
++    NULL,                                  /* exit thread */
++    NULL,                                  /* exit process */
++    NULL,                                  /* exit master */
++    NGX_MODULE_V1_PADDING
++};
++
++
++static ngx_int_t  
++get_int_from_query(ngx_http_request_t *r, char *name, size_t len)
++{
++    ngx_str_t   val;
++
++    if (ngx_http_arg(r, (u_char *) name, len, &val) == NGX_OK) {
++        if (val.len == 0)
++            return -1;
++        
++        return ngx_atoi(val.data, val.len);
++    }
++    else
++        return -1;
++}
++
++
++static char *  
++sortingColumns(ngx_http_request_t *r)
++{
++    u_char  *p, *last;
++    u_char  *data;
++    char  *colnum, *current;
++    ngx_uint_t  len;
++    ngx_int_t   colcnt = 0;
++
++    if (r->args.len == 0) {
++        return "9r-10r";  /* default */
++    }
++    
++    colnum = current = ngx_pcalloc(r->pool, 8);
++    if (colnum == NULL) {
++        return "9r-10r";
++    }
++
++    p = r->args.data;
++    last = p + r->args.len;
++    len = 4;  /* 4 = sizeof("sort") - 1  */
++
++    for ( /* void */ ; p < last; p++) {
++
++        p = ngx_strlcasestrn(p, last - 1, (u_char *)"sort", len - 1);
++
++        if (p == NULL) {
++            return "9r-10r"; 
++        }
++
++        if ((p == r->args.data || *(p - 1) == '&') && *(p + len) == '=') {
++
++            data = p + len + 1;
++
++            p = ngx_strlchr(p, last, '&');
++
++            if (p == NULL) {
++                p = r->args.data + r->args.len;
++            }    
++
++            /*
++              3: Maximum size of a column number (ex. 1, 3r 10r)
++              8: Maximum size of two column numbers + 1(for NULL) (ex. 1-2, 7r-3, 10r-11r)
++             */
++            if (p - data <= 3 && (p - data + 1) < (8 - (current - colnum)))  {
++               
++                if (colnum != current) {
++                    *current++ = '-' ;
++                    colcnt += 1;
++                }
++                else
++                    colcnt = 1 ;
++
++                ngx_memcpy(current, data, p - data);
++                current += p - data;
++            }
++        }
++        if (2 <= colcnt)
++            break;
++    }
++    
++    if (colnum == current)
++        return "9r-10r";
++    else
++        return colnum;
++}
++
++
++/* coped from ngx_http_gzip_ratio_variable()@ngx_http_gzip_filter_module.c  */
++static  float
++get_gzip_ratio(size_t zin, size_t zout)
++{
++    ngx_uint_t  zint, zfrac;
++    float       ratio = 0.0;
++
++    if (zin == 0 || zout == 0)
++        return ratio;
++
++    zint = (ngx_uint_t) (zin / zout);
++    zfrac = (ngx_uint_t) ((zin * 100 / zout) % 100);
++    
++    if ((zin * 1000 / zout) % 10 > 4) {
++        zfrac++;
++
++	if (zfrac > 99)	{
++	    zint++;
++	    zfrac = 0;
++	}
++    }
++
++    ratio = zint + ((float) zfrac / 100.0);
++
++    return ratio;
++}
++
++
++static ngx_int_t  
++how_long_ago_used(time_t  last_sec)
++{
++    ngx_time_t  *tp;
++    ngx_int_t    sec;
++
++    tp = ngx_timeofday();
++    sec = tp->sec - last_sec;
++    sec = sec < 0 ? 0 : sec;
++
++    return sec;
++}
++
++
++static ngx_int_t  
++set_refresh_header_field(ngx_http_request_t  *r)
++{
++    ngx_int_t  refresh;
++
++    refresh = get_int_from_query(r, "refresh", 7);
++
++    if (MIN_REFRESH_VALUE < refresh && refresh <= MAX_REFRESH_VALUE) {
++        ngx_table_elt_t  *h;
++	u_char           *refresh_value;
++
++	h = ngx_list_push(&r->headers_out.headers);
++	if (NULL == h)
++	    return NGX_HTTP_INTERNAL_SERVER_ERROR;
++	refresh_value = ngx_pnalloc(r->pool, 32);
++	if (refresh_value == NULL) 
++	    return NGX_HTTP_INTERNAL_SERVER_ERROR;
++	else
++	    memset(refresh_value, 0, 32);
++
++	h->hash = 1;
++	h->key.len = sizeof("Refresh") - 1;
++	h->key.data = (u_char *) "Refresh";
++	ngx_sprintf(refresh_value, "%d", refresh);
++	h->value.data = refresh_value;
++	h->value.len = strlen((const char *) h->value.data);
++	    
++	r->headers_out.refresh = h;
++    }
++
++    return 0;
++}
++
++
++static u_char  *
++get_hostname(ngx_http_request_t  *r)
++{
++    u_char  *hostname = NULL;
++
++    hostname = ngx_pnalloc(r->pool, ngx_cycle->hostname.len + 1);
++    if (hostname == NULL)
++        return NULL;
++
++    ngx_cpystrn(hostname, ngx_cycle->hostname.data, ngx_cycle->hostname.len + 1);  
++
++    return hostname;
++}
++
++
++static ngx_chain_t *
++put_header(ngx_http_request_t  *r)
++{
++    ngx_chain_t  *c;
++    ngx_buf_t  *b;
++
++    b = ngx_create_temp_buf(r->pool, sizeof(HTML_HEADER));
++    if (b == NULL) 
++        return NULL;
++    c = ngx_pcalloc(r->pool, sizeof(ngx_chain_t));
++    if (c == NULL) 
++        return NULL;
++
++    b->last = ngx_sprintf(b->last, HTML_HEADER);
++    c->buf = b;
++    c->next = NULL;
++
++    return c;
++}
++
++
++static ngx_chain_t *
++put_server_info(ngx_http_request_t  *r)
++{
++    ngx_chain_t  *c;
++    ngx_buf_t  *b;
++    u_char  *hostname; 
++    size_t  size ;
++
++    size = sizeof(SERVER_INFO) + ngx_cycle->hostname.len + sizeof(NGINX_VERSION) + sizeof("<hr /><br>");
++    b = ngx_create_temp_buf(r->pool, size);
++    if (b == NULL) 
++        return NULL;
++    c = ngx_pcalloc(r->pool, sizeof(ngx_chain_t));
++    if (c == NULL) 
++        return NULL;
++
++    hostname = get_hostname(r);
++    if (hostname == NULL)
++        return NULL;
++
++    b->last = ngx_sprintf(b->last, SERVER_INFO, hostname, NGINX_VERSION);
++    b->last = ngx_sprintf(b->last, "<hr /><br>"); 
++
++    c->buf = b;
++    c->next = NULL;
++
++    return c;
++}
++
++
++static ngx_chain_t *
++put_basic_status(ngx_http_request_t  *r)
++{
++    ngx_chain_t  *c;
++    ngx_buf_t  *b;
++    ngx_atomic_int_t  ap, hn, ac, rq, rd, wr;
++    size_t  size;
++
++    ap = *ngx_stat_accepted;
++    hn = *ngx_stat_handled;
++    ac = *ngx_stat_active;
++    rq = *ngx_stat_requests;
++    rd = *ngx_stat_reading;
++    wr = *ngx_stat_writing;
++
++    size = sizeof("<b>Active connections: %uA </b>\n<br><br>\n") + NGX_ATOMIC_T_LEN;
++    size += sizeof("<table border=0><tr><th>server accepts</th><th>handled</th><th>requests</th></tr>\n");
++    size += sizeof("<tr align=right><td> %uA </td><td> %uA </td><td> %uA </td></tr></table><br>\n") + NGX_ATOMIC_T_LEN * 3;
++    size += sizeof("<table border=0><tr><th>Reading:</th><td> %uA </td><th>Writing:</th><td> %uA </td><th>Waiting:</th><td> %uA </td></tr></table>\n") 
++        + NGX_ATOMIC_T_LEN * 3;
++	
++    b = ngx_create_temp_buf(r->pool, size);
++    if (b == NULL) 
++        return NULL;
++    c = ngx_pcalloc(r->pool, sizeof(ngx_chain_t));
++    if (c == NULL) 
++        return NULL;
++
++    b->last = ngx_sprintf(b->last, "<b>Active connections: %uA </b>\n<br><br>\n", ac);
++    b->last = ngx_sprintf(b->last, "<table border=0><tr><th>server accepts</th><th>handled</th><th>requests</th></tr>\n");
++    b->last = ngx_sprintf(b->last, "<tr align=right><td> %uA </td><td> %uA </td><td> %uA </td></tr></table><br>\n", ap, hn, rq);
++    b->last = ngx_sprintf(b->last, "<table border=0><tr><th>Reading:</th><td> %uA </td><th>Writing:</th><td> %uA </td><th>Waiting:</th><td> %uA </td></tr></table>\n", 
++                          rd, wr, ac - (rd + wr));
++    c->buf = b;
++    c->next = NULL;
++    
++    return c;
++}
++
++
++static inline ngx_uint_t
++dec_qps_index(ngx_uint_t index)
++{
++    return index == 0 ? RECENT_PERIOD - 1 : index - 1;
++}
++
++
++static ngx_chain_t *
++put_worker_status(ngx_http_request_t *r)
++{
++    worker_score  *ws;
++    ngx_time_t    *tp;
++    ngx_chain_t   *c;
++    ngx_buf_t     *b;
++    uint32_t       query_cnt_1 = 0;
++    uint32_t       query_cnt_2 = 0;
++    uint32_t       current;
++    uint32_t       past;
++    uint32_t       index;
++    uint32_t       tmp_idx;
++    uint32_t       hz = sysconf(_SC_CLK_TCK);
++    uint32_t       i, j;
++    size_t  size;
++    size_t  sizePerWorker;
++
++    if (PERIOD_L <= PERIOD_S || RECENT_PERIOD <= PERIOD_L)
++        return NGX_OK;
++
++    tp = ngx_timeofday();
++    current = (uint32_t) tp->sec;
++    current -= 1;
++    index = current & RECENT_MASK;
++
++    size = sizeof(WORKER_TABLE_HEADER);
++
++    sizePerWorker = sizeof("<tr><td align=center>%4d</td>") + 4;
++    sizePerWorker += sizeof("<td> %5d </td>") + 5; /* size of /proc/sys/kernel/pid_max */
++    sizePerWorker += sizeof("<td align=right> %d </td>") + NGX_INT64_LEN;
++    sizePerWorker += sizeof("<td align=center><b> %c </b></td>");
++    sizePerWorker += sizeof("<td> %.2f </td>") + 5; 
++    sizePerWorker += sizeof("<td align=right> %.2f </td></tr>") + NGX_INT64_LEN; 
++
++    size += sizePerWorker * ngx_num_workers;
++    size += sizeof("</table>\n<br><br>");
++    size += sizeof("<b>Requests/sec: %.02f (last %2d seconds), %.02f (last %2d seconds) &nbsp; &nbsp; at %s</b><br>");
++    size += 7 + 2 + 7 + 2;
++    size += sizeof(CURRENT_TIME);
++        
++    b = ngx_create_temp_buf(r->pool, size);
++    if (b == NULL) 
++        return NULL;
++
++    c = ngx_pcalloc(r->pool, sizeof(ngx_chain_t));
++    if (c == NULL) 
++        return NULL;
++
++    b->last = ngx_sprintf(b->last, WORKER_TABLE_HEADER);
++    for (i = 0; i < ngx_num_workers; i++) {
++	ws = (worker_score *) ((char *)workers + WORKER_SCORE_LEN * i);
++
++	b->last = ngx_sprintf(b->last, "<tr><td align=center>%4d</td>", i);	
++	b->last = ngx_sprintf(b->last, "<td> %5d </td>", ws->pid);    
++	b->last = ngx_sprintf(b->last, "<td align=right> %d </td>", ws->access_count);
++	b->last = ngx_sprintf(b->last, "<td align=center><b> %c </b></td>", ws->mode);    
++	b->last = ngx_sprintf(b->last, "<td> %.2f </td>",   
++                              (ws->times.tms_utime + ws->times.tms_stime + 
++                               ws->times.tms_cutime + ws->times.tms_cstime) / (float) hz);
++	b->last = ngx_sprintf(b->last, "<td align=right> %.2f </td></tr>", (float) ws->bytes_sent / MBYTE);
++
++	tmp_idx = index;
++	past = current;
++	for (j = 0; j < PERIOD_L; j++) {
++	    if (past == ws->recent_request_cnt [tmp_idx].time) {
++	        query_cnt_2 += ws->recent_request_cnt [tmp_idx].cnt;
++		if (j < PERIOD_S)
++		    query_cnt_1 += ws->recent_request_cnt [tmp_idx].cnt;
++	    }
++
++	    tmp_idx = dec_qps_index(tmp_idx);	    
++	    past -= 1;
++	}
++    }
++    b->last = ngx_sprintf(b->last, "</table>\n<br><br>");	    
++    b->last = ngx_sprintf(b->last, "<b>Requests/sec: %.02f (last %2d seconds), %.02f (last %2d seconds) &nbsp; &nbsp; at %s</b><br>", 
++                          (float)query_cnt_1 / (float)PERIOD_S, PERIOD_S, 
++                          (float)query_cnt_2 / (float)PERIOD_L, PERIOD_L, 
++                          CURRENT_TIME);
++    c->buf = b;
++    c->next = NULL;
++
++    return c;
++}
++
++
++static ngx_chain_t *
++put_connection_status(ngx_http_request_t *r)
++{
++    ngx_msec_int_t  response_time;	
++    conn_score     *cs;
++    ngx_uint_t      i, j, k;
++    int             active;
++    ngx_chain_t   *c, *c1, *c2;
++    ngx_buf_t     *b;
++    size_t   sizePerConn;
++    size_t   sizePerWorker;
++
++    response_time = get_int_from_query(r, "res", 3);
++    if (response_time < 0)
++        response_time = DEFAULT_REQ_VALUE;
++    active = get_int_from_query(r, "active", 6);
++    
++
++    sizePerConn = sizeof("<tr><td align=center>%4d-%04d</td>") + 4 + 4;
++    sizePerConn += sizeof("<td align=right> %d </td>") + NGX_INT64_LEN;
++    sizePerConn += sizeof("<td align=center><b>%c</b></td>");
++    sizePerConn += sizeof("<td align=right> %d </td>") + NGX_INT64_LEN;
++    sizePerConn += sizeof("<td> %s </td>") + SCORE__CLIENT_LEN;
++    sizePerConn += sizeof("<td> %s </td>") + SCORE__VHOST_LEN;
++    sizePerConn += sizeof("<td align=right> %.02f </td>") + 5;
++    sizePerConn += sizeof("<td align=right> %d </td>") + NGX_INT64_LEN;
++    sizePerConn += sizeof("<td align=right> %ui </td>") + 3;
++    sizePerConn += sizeof("<td align=right> %d </td>") + NGX_INT64_LEN;
++    sizePerConn += sizeof("<td align=right> %d </td>") + NGX_INT64_LEN;  
++    sizePerConn += sizeof("<td> %s </td></tr>") + SCORE__REQUEST_LEN;
++    sizePerWorker = sizePerConn * ngx_cycle->connection_n;
++       
++    /* 7 = sizeof("10r-10r") - 1 */
++    b = ngx_create_temp_buf(r->pool, sizeof(CONNECTION_TABLE_HEADER) + 7 + sizePerWorker);  
++    if (b == NULL) 
++        return NULL;
++    c = c1 = ngx_pcalloc(r->pool, sizeof(ngx_chain_t));
++    if (c == NULL) 
++        return NULL;
++
++    c->buf = b;
++    c->next = NULL;
++
++    b->last = ngx_sprintf(b->last, CONNECTION_TABLE_HEADER, sortingColumns(r));
++    for (i = 0; i < ngx_num_workers; i++) {
++        for ( j = 0 ; j < ngx_cycle->connection_n ; j++ ) {
++	    k = i * ngx_cycle->connection_n + j ;
++	    cs = (conn_score *) ((char *)conns + sizeof(conn_score) * k);
++
++	    if (cs->response_time < response_time || 
++                '\0' ==  cs->client [0] || 
++                '\0' == cs->request [0] || 
++                '\0' == cs->vhost [0])
++	        continue;
++	    if (0 < active && 0 == cs->active)
++	        continue;
++
++	    b->last = ngx_sprintf(b->last, "<tr><td align=center>%4d-%04d</td>", i, j);
++	    
++	    b->last = ngx_sprintf(b->last, "<td align=right> %d </td>", cs->access_count);
++	    b->last = ngx_sprintf(b->last, "<td align=center><b>%c</b></td>", cs->mode);	    
++	    b->last = ngx_sprintf(b->last, "<td align=right> %d </td>", cs->bytes_sent);
++	    
++	    b->last = ngx_sprintf(b->last, "<td> %s </td>", cs->client);
++	    b->last = ngx_sprintf(b->last, "<td> %s </td>", cs->vhost);
++	
++	    if (0 != cs->zin && 0 != cs->zout)
++	        b->last = ngx_sprintf(b->last, "<td align=right> %.02f </td>", get_gzip_ratio(cs->zin, cs->zout));
++	    else
++	        b->last = ngx_sprintf(b->last, "<td align=center> - </td>");
++
++	    b->last = ngx_sprintf(b->last, "<td align=right> %d </td>", how_long_ago_used(cs->last_used));
++	    b->last = ngx_sprintf(b->last, "<td align=right> %ui </td>", cs->status);
++
++	    b->last = ngx_sprintf(b->last, "<td align=right> %d </td>", cs->response_time);
++
++	    if (0 <= cs->upstream_response_time)
++	        b->last = ngx_sprintf(b->last, "<td align=right> %d </td>", cs->upstream_response_time);	
++	    else
++	        b->last = ngx_sprintf(b->last, "<td align=center><b>-</b></td>");	
++
++	    b->last = ngx_sprintf(b->last, "<td> %s </td></tr>", cs->request);
++	}
++        
++        if (i + 1 < ngx_num_workers)
++            b = ngx_create_temp_buf(r->pool, sizePerWorker);
++        else
++            b = ngx_create_temp_buf(r->pool, sizeof("</tbody></table><hr /><br>\n"));
++        if (b == NULL) 
++            return NULL;
++        c2 = ngx_pcalloc(r->pool, sizeof(ngx_chain_t));
++        if (c2 == NULL) 
++            return NULL;
++
++        c2->buf = b;
++        c2->next = NULL;
++        c1->next = c2;
++        c1 = c2;
++    }
++
++    b->last = ngx_sprintf(b->last, "</tbody></table><hr /><br>\n");
++
++    return c;
++}
++
++
++static ngx_chain_t  *
++put_footer(ngx_http_request_t *r)
++{
++    ngx_chain_t  *c;
++    ngx_buf_t  *b;
++    size_t  size;
++
++    size = sizeof(SHORTENED_TABLE);
++    size += sizeof("<hr />");
++    size += sizeof(MODE_LIST);
++    size += sizeof(HTML_TAIL);
++    
++    b = ngx_create_temp_buf(r->pool, size);
++    if (b == NULL) 
++        return NULL;
++    c = ngx_pcalloc(r->pool, sizeof(ngx_chain_t));
++    if (c == NULL) 
++        return NULL;
++
++    b->last = ngx_sprintf(b->last, SHORTENED_TABLE);
++    b->last = ngx_sprintf(b->last, "<hr />");
++    b->last = ngx_sprintf(b->last, MODE_LIST);
++
++    b->last = ngx_sprintf(b->last, HTML_TAIL);
++
++    c->buf = b ;
++    c->next = NULL;
++
++    return c;
++} 
++
++
++static inline ngx_chain_t *
++get_lastChain( ngx_chain_t  *c)
++{
++    ngx_chain_t  *last = c;
++
++    assert(last != NULL);
++
++    while ( last->next != NULL )
++        last = last->next;
++
++    return last;
++}
++
++
++static inline off_t
++get_contentLength(ngx_chain_t  *c)
++{
++    off_t  l = 0;
++
++    while (c != NULL) {
++        l += ngx_buf_size(c->buf);
++        c = c->next;
++    }
++    
++    return l;
++}
++
++
++static ngx_int_t 
++ngx_http_status_handler(ngx_http_request_t *r)
++{
++    ngx_chain_t  *fc, *mc, *lc;
++    ngx_int_t    rc;
++
++    if (NGX_HTTP_GET != r->method)
++        return NGX_HTTP_NOT_ALLOWED;
++
++    rc = ngx_http_discard_request_body(r);
++    if (rc != NGX_OK) 
++        return rc;
++
++    r->headers_out.content_type.len  = sizeof( "text/html; charset=ISO-8859-1" ) - 1;
++    r->headers_out.content_type.data = (u_char *) "text/html; charset=ISO-8859-1";
++
++    rc = set_refresh_header_field(r);
++    if ( rc != NGX_OK)
++        return rc;
++
++    fc = put_header(r);
++    if (fc == NULL)
++        return NGX_HTTP_INTERNAL_SERVER_ERROR;
++    lc = get_lastChain(fc);
++
++    mc = put_server_info(r);
++    if (mc == NULL)
++        return NGX_HTTP_INTERNAL_SERVER_ERROR;
++    lc->next = mc;
++    lc = get_lastChain(mc);
++
++    mc = put_basic_status(r);
++    if (mc == NULL)
++        return NGX_HTTP_INTERNAL_SERVER_ERROR;
++    lc->next = mc;
++    lc = get_lastChain(mc);
++
++    mc = put_worker_status(r);
++    if (mc == NULL)
++        return NGX_HTTP_INTERNAL_SERVER_ERROR;
++    lc->next = mc;
++    lc = get_lastChain(mc);
++
++    mc = put_connection_status(r);
++    if (mc == NULL)
++        return NGX_HTTP_INTERNAL_SERVER_ERROR;
++    lc->next = mc;
++    lc = get_lastChain(mc);
++
++    mc = put_footer(r);
++    if (mc == NULL)
++        return NGX_HTTP_INTERNAL_SERVER_ERROR;
++    lc->next = mc;
++    lc = get_lastChain(mc);
++
++    lc->buf->last_buf = 1;
++
++    r->headers_out.status = NGX_HTTP_OK;
++    r->headers_out.content_length_n = get_contentLength(fc);
++
++    rc = ngx_http_send_header(r);
++    if (NGX_ERROR == rc || NGX_OK < rc || r->header_only) 
++        return rc;
++
++    return ngx_http_output_filter(r, fc);
++}
++
++
++static char *
++ngx_http_set_status(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
++{
++    ngx_http_core_loc_conf_t  *clcf;
++
++    clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
++    clcf->handler = ngx_http_status_handler;
++
++    return NGX_CONF_OK;
++}
+diff -ruN capione_ngx-1.9.7.4/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module.h capione_ngx-1.9.7.4-new/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module.h
+--- capione_ngx-1.9.7.4/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module.h	1969-12-31 19:00:00.000000000 -0500
++++ capione_ngx-1.9.7.4-new/bundle/ngx_http_extended_status_module/src/ngx_http_extended_status_module.h	2016-04-04 15:15:20.000000000 -0400
+@@ -0,0 +1,65 @@
++
++
++#define  HTML_HEADER    "<html><head><title>Nginx Status</title>\n" \
++        "<script type=text/javascript src=tablesort.min.js></script>\n" \
++        "<style type=text/css><!--\n" \
++        "body{font:bold 15px Georgia, Helvetica, sans-serif;color:#4f6b72;}\n" \
++        "table{border-top:1px solid #e5eff8;border-right:1px solid #e5eff8;border-collapse:collapse;}\n" \
++        "th{font:bold 10px \"Century Gothic\", \"Trebuchet MS\", Helvetica, sans-serif;letter-spacing:1px;text-transform:uppercase;background:#f4f9fe;color:#66a3d3;border-bottom:1px solid #e5eff8;border-left:1px solid #e5eff8;padding:8px 5px;}\n" \
++        "td{border-bottom:1px solid #e5eff8;border-left:1px solid #e5eff8;}\n" \
++        "tbody td{font:13px Calibri,\"Trebuchet MS\", Helvetica, sans-serif;padding:5px;}\n" \
++        "tr:hover{background: #d0dafd;color:#000000}\n" \
++        "--></style>\n" \
++        "</head>\n<body>\n"
++
++#define  HTML_TAIL        "\n</body></html>"
++
++#define  SAVE_THIS_PAGE   "<input type=button onclick=javascript:saveCurrentState() value=\"Save this page\"><br><br>\n"
++
++#define  SERVER_INFO      "<h1> Nginx Server Status for %s</h1>\n<dl><dt>Server Version: Nginx/%s </dt></dl>\n"
++
++
++#define  WORKER_TABLE_HEADER   "<br><br>\n<table border=0><tr><th>Worker</th><th>PID</th><th>Acc</th><th>Mode</th><th>CPU</th>" \
++                               "<th>Mbytes</th></tr>\n" 
++
++#define  CURRENT_TIME          "<script type=text/javascript> var date = new Date() ; document.write( date.toLocaleString() );</script>"
++
++#define  CONNECTION_TABLE_HEADER     "<br><br>\n<table class=sortable-onload-%s cellspacing=1 border=0 cellpadding=1>\n" \
++                               "<thead><tr><th class=sortable>Worker</th><th class=sortable>Acc</th><th class=sortable>M</th>\n" \
++                               "<th class=sortable>Bytes</th><th class=sortable>Client</th><th class=sortable>VHost</th>\n" \
++                               "<th class=sortable>Gzip Ratio</th><th class=sortable>SS</th><th class=sortable>Status</th>\n" \
++                               "<th class=sortable>TIME</th><th class=sortable>Proxy TIME</th><th class=sortable>Request</th></tr></thead><tbody>\n"
++
++#define  GZIP_HEADER    "<th class=sortable>Gzip Ratio</th>"
++#define  PROXY_HEADER   "<th class=sortable>Proxy TIME</th>"
++
++#define  SHORTENED_TABLE  "<table>\n"  \
++                     "<tr><th>PID</th><td>OS process ID</td></tr>\n" \
++                     "<tr><th>Acc</th><td>Number of requests serviced with this connection slot</td></tr>\n" \
++                     "<tr><th>M</th><td>Mode of operation</td></tr>\n" \
++                     "<tr><th>CPU</th><td>Accumulated CPU usage in seconds</td></tr>\n" \
++                     "<tr><th>Gzip Ratio</th><td>Ratio of original size to compressed size </td>\n" \
++                     "<tr><th>SS</th><td>Seconds since the request completion</td></tr>\n" \
++                     "<tr><th>Proxy TIME</th><td> Proxy response time in milliseconds. 0 means the value is less than 1 millisecond</td></tr>\n" \
++                     "<tr><th>TIME</th><td>Response time in milliseconds. 0 means the value is less than 1 millisecond</td></tr>\n" \
++                     "</table>\n" 
++
++#define  MODE_LIST  "<b>Mode List</b><br><table>" \
++                    "<tr><th>-</th><td>Waiting for request</td></tr>\n" \
++                    "<tr><th>R</th><td>Reading request</td></tr>\n" \
++                    "<tr><th>W</th><td>Sending reply</td></tr>\n" \
++                    "<tr><th>L</th><td>Logging</td></tr>\n" \
++                    "<tr><th>I</th><td>Inactive connection</td></tr>\n"
++
++
++#define  MBYTE  1048576.0
++
++#define  DEFAULT_REQ_VALUE    0
++
++#define  MIN_REFRESH_VALUE    0
++#define  MAX_REFRESH_VALUE   60
++
++#define  PERIOD_S     10    /* 10 seconds */
++#define  PERIOD_L     60    /* 60 seconds */
++
++
+diff -ruN capione_ngx-1.9.7.4/capione_install.sh capione_ngx-1.9.7.4-new/capione_install.sh
+--- capione_ngx-1.9.7.4/capione_install.sh	2016-03-25 10:19:57.000000000 -0400
++++ capione_ngx-1.9.7.4-new/capione_install.sh	2016-04-05 14:16:29.000000000 -0400
+@@ -22,9 +22,9 @@
+ 
+ echo "*********Configure for compilation"
+ if [ "${os}" = "Darwin" ]; then
+-    ./configure --with-pcre-jit --with-luajit --with-cc-opt="-I/usr/local/include -I/usr/local/Cellar/openssl/1.0.1g/include/" --with-ld-opt="-L/usr/local/lib -L/usr/local/Cellar/openssl/1.0.1g/lib" --prefix=/opt/capione  --with-http_realip_module 
++    ./configure --with-pcre-jit --with-luajit --with-cc-opt="-I/usr/local/include -I/usr/local/Cellar/openssl/1.0.1g/include/" --with-ld-opt="-L/usr/local/lib -L/usr/local/Cellar/openssl/1.0.1g/lib" --prefix=/opt/capione  --with-http_realip_module --with-http_stub_status_module --add-module=build/ngx_http_extended_status_module
+ else
+-    ./configure --with-pcre-jit --with-luajit --with-cc-opt="-I/usr/local/include" --with-ld-opt="-L/usr/local/lib" --prefix=/opt/capione --with-http_realip_module --user=capione
++    ./configure --with-pcre-jit --with-luajit --with-cc-opt="-I/usr/local/include" --with-ld-opt="-L/usr/local/lib" --prefix=/opt/capione --with-http_realip_module --with-http_stub_status_module --add-module=build/ngx_http_extended_status_module --user=capione
+ fi
+ 
+ echo "*********Make....."
+diff -ruN capione_ngx-1.9.7.4/configure capione_ngx-1.9.7.4-new/configure
+--- capione_ngx-1.9.7.4/configure	2016-03-16 20:37:27.000000000 -0400
++++ capione_ngx-1.9.7.4-new/configure	2016-04-05 10:05:22.000000000 -0400
+@@ -182,6 +182,9 @@
+     } elsif ($opt eq '--without-lua_cjson') {
+         $resty_opts{no_lua_cjson} = 1;
+ 
++    } elsif ($opt eq '--without-lua_cmsgpack') {
++        $resty_opts{no_lua_cmsgpack} = 1;
++
+     } elsif ($opt eq '--without-lua_redis_parser') {
+         $resty_opts{no_lua_redis_parser} = 1;
+ 
+@@ -830,6 +833,62 @@
+                 "\$(MAKE) install$extra_opts";
+         }
+ 
++        unless ($opts->{no_lua_cmsgpack}) {
++            my $dir = auto_complete 'lua-cmsgpack';
++            if (!defined $dir) {
++                die "No lua-cmsgpack found";
++            }
++
++            my $lua_inc;
++            if ($opts->{luajit} || $opts->{luajit_path}) {
++                $lua_inc = $ENV{LUAJIT_INC};
++
++            } else {
++                $lua_inc = $ENV{LUA_INC};
++            }
++
++            my $extra_opts = " DESTDIR=\$(DESTDIR) LUA_INCLUDE_DIR=$lua_inc " .
++                "LUA_CMODULE_DIR=$lualib_prefix LUA_MODULE_DIR=$lualib_prefix";
++
++            if ($platform eq 'msys') {
++                my $luajit_root = File::Spec->rel2abs("luajit-root");
++                $extra_opts .= " CMSGPACK_LDFLAGS=\"-shared -L$luajit_root -llua51\"";
++            }
++
++            if ($on_solaris) {
++                #$extra_opts .= " INSTALL=$root_dir/build/install";
++                if ($opts->{debug}) {
++                    $extra_opts .= " CMSGPACK_LDFLAGS=\"-g -O -fpic -DUSE_INTERNAL_ISINF\"";
++
++                } else {
++                    $extra_opts .= " CMSGPACK_LDFLAGS=\"-g -fpic -DUSE_INTERNAL_ISINF\"";
++                }
++
++            } else {
++                if ($opts->{debug}) {
++                    $extra_opts .= " CMSGPACK_LDFLAGS=\"-g -O -fpic\"";
++                } else {
++                    $extra_opts .= " CMSGPACK_LDFLAGS=\"-g -fpic\"";
++                }
++            }
++
++            if ($platform eq 'macosx') {
++                $extra_opts .= " CMSGPACK_LDFLAGS='-bundle -undefined dynamic_lookup'";
++            }
++
++            if (defined $cc) {
++                $extra_opts .= " CC='$cc'";
++            } else {
++                $extra_opts .= " CC=cc";
++            }
++
++            push @make_cmds, "cd $root_dir/build/$dir && ".
++                "\$(MAKE)$extra_opts";
++
++            push @make_install_cmds, "cd $root_dir/build/$dir && " .
++                "\$(MAKE) install$extra_opts";
++        }
++
+         unless ($opts->{no_lua_redis_parser}) {
+             my $dir = auto_complete 'lua-redis-parser';
+             if (!defined $dir) {

--- a/ngx_http_extended_status_module.h
+++ b/ngx_http_extended_status_module.h
@@ -1,4 +1,14 @@
+#define SERVER_CONN_STATS "{\n  \"server\" : {\"host\" : \"%s\",\"nginx-version\" : \"%s\"},\n  \"connection_info\" : { \"active_connections\" : %uA, \"server_accepts\" : %uA, \"handled\" : %uA, \"requests\" : %uA, \"reading\" : %uA, \"writing\" : %uA, \"waiting\" : %uA },\n  \"workers\" : [ "
+                            
 
+                     
+#define WORKER_STATS "\n      { \"pid\" : %5d, \"num_req_served\": %d, \"operation_mode\": \"%c\", \"cpu\": %.2f, \"mbytes\": %.2f }%c"   
+
+#define CONNNECTIONS_STATS ",\n  \"connections\": [ "
+
+#define CONNECTION_STATS "%c\n    { \"worker\": \"%4d-%04d\" , \"operation_mode\": \"%c\" , \"num_req_served\": %d , \"mbytes\": %.2f , \"client\" : \"%s\" , \"vhost\": \"%s\" , \"seconds_since_req_completion\": %d , \"status\" : %ui , \"response_time\" :  %d , \"upstream_response_time\" :%d , \"request\" : \"%s\" }"                             
+
+#define CONNNECTIONS_CLOSE_STATS "\n   ]\n}"
 
 #define  HTML_HEADER    "<html><head><title>Nginx Status</title>\n" \
         "<script type=text/javascript src=tablesort.min.js></script>\n" \


### PR DESCRIPTION
1. Added support for returning nginx status in json format. See README
2. Created a patch to return status data in the json format based on the flag (extended_status_content_type_json on;)
